### PR TITLE
Release branch v1.2.1

### DIFF
--- a/cmd/ctrld/cli.go
+++ b/cmd/ctrld/cli.go
@@ -234,6 +234,8 @@ func initCLI() {
 	runCmd.Flags().StringVarP(&logPath, "log", "", "", "Path to log file")
 	runCmd.Flags().IntVarP(&cacheSize, "cache_size", "", 0, "Enable cache with size items")
 	runCmd.Flags().StringVarP(&cdUID, "cd", "", "", "Control D resolver uid")
+	runCmd.Flags().BoolVarP(&cdDev, "dev", "", false, "Use Control D dev resolver/domain")
+	_ = runCmd.Flags().MarkHidden("dev")
 	runCmd.Flags().StringVarP(&homedir, "homedir", "", "", "")
 	_ = runCmd.Flags().MarkHidden("homedir")
 	runCmd.Flags().StringVarP(&iface, "iface", "", "", `Update DNS setting for iface, "auto" means the default interface gateway`)
@@ -352,6 +354,8 @@ func initCLI() {
 	startCmd.Flags().StringVarP(&logPath, "log", "", "", "Path to log file")
 	startCmd.Flags().IntVarP(&cacheSize, "cache_size", "", 0, "Enable cache with size items")
 	startCmd.Flags().StringVarP(&cdUID, "cd", "", "", "Control D resolver uid")
+	startCmd.Flags().BoolVarP(&cdDev, "dev", "", false, "Use Control D dev resolver/domain")
+	_ = startCmd.Flags().MarkHidden("dev")
 	startCmd.Flags().StringVarP(&iface, "iface", "", "", `Update DNS setting for iface, "auto" means the default interface gateway`)
 	startCmd.Flags().BoolVarP(&setupRouter, "router", "", false, `setup for running on router platforms`)
 	_ = startCmd.Flags().MarkHidden("router")
@@ -706,7 +710,7 @@ func processCDFlags() {
 	}
 	logger := mainLog.With().Str("mode", "cd").Logger()
 	logger.Info().Msgf("fetching Controld D configuration from API: %s", cdUID)
-	resolverConfig, err := controld.FetchResolverConfig(cdUID, rootCmd.Version)
+	resolverConfig, err := controld.FetchResolverConfig(cdUID, rootCmd.Version, cdDev)
 	if uer, ok := err.(*controld.UtilityErrorResponse); ok && uer.ErrorField.Code == controld.InvalidConfigCode {
 		s, err := service.New(&prog{}, svcConfig)
 		if err != nil {

--- a/cmd/ctrld/cli.go
+++ b/cmd/ctrld/cli.go
@@ -312,7 +312,7 @@ func initCLI() {
 				{s.Start, true},
 			}
 			if doTasks(tasks) {
-				if err := router.PostInstall(); err != nil {
+				if err := router.PostInstall(svcConfig); err != nil {
 					mainLog.Warn().Err(err).Msg("post installation failed, please check system/service log for details error")
 					return
 				}
@@ -468,7 +468,7 @@ NOTE: Uninstalling will set DNS to values provided by DHCP.`,
 				}
 				prog.resetDNS()
 				mainLog.Debug().Msg("Router cleanup")
-				if err := router.Cleanup(); err != nil {
+				if err := router.Cleanup(svcConfig); err != nil {
 					mainLog.Warn().Err(err).Msg("could not cleanup router")
 				}
 				mainLog.Notice().Msg("Service uninstalled")

--- a/cmd/ctrld/cli.go
+++ b/cmd/ctrld/cli.go
@@ -890,7 +890,7 @@ func selfCheckStatus(status service.Status) service.Status {
 			mainLog.Debug().Msgf("self-check against %q succeeded", selfCheckFQDN)
 			return status
 		}
-		bo.BackOff(ctx, err)
+		bo.BackOff(ctx, fmt.Errorf("ExchangeContext: %w", err))
 	}
 	mainLog.Debug().Msgf("self-check against %q failed", selfCheckFQDN)
 	return service.StatusUnknown

--- a/cmd/ctrld/cli.go
+++ b/cmd/ctrld/cli.go
@@ -165,8 +165,12 @@ func initCLI() {
 			initLogging()
 
 			if setupRouter {
-				if err := router.PreStart(); err != nil {
+				s, _ := runDNSServerForNTPD()
+				if err := router.PreRun(); err != nil {
 					mainLog.Fatal().Err(err).Msg("failed to perform router pre-start check")
+				}
+				if err := s.Shutdown(); err != nil {
+					mainLog.Fatal().Err(err).Msg("failed to shutdown dns server for ntpd")
 				}
 			}
 
@@ -909,7 +913,7 @@ func unsupportedPlatformHelp(cmd *cobra.Command) {
 
 func userHomeDir() (string, error) {
 	switch router.Name() {
-	case router.DDWrt, router.Merlin:
+	case router.DDWrt, router.Merlin, router.Tomato:
 		exe, err := os.Executable()
 		if err != nil {
 			return "", err

--- a/cmd/ctrld/cli.go
+++ b/cmd/ctrld/cli.go
@@ -165,11 +165,11 @@ func initCLI() {
 			initLogging()
 
 			if setupRouter {
-				s, _ := runDNSServerForNTPD()
+				s, errCh := runDNSServerForNTPD(router.ListenAddress())
 				if err := router.PreRun(); err != nil {
 					mainLog.Fatal().Err(err).Msg("failed to perform router pre-start check")
 				}
-				if err := s.Shutdown(); err != nil {
+				if err := s.Shutdown(); err != nil && errCh != nil {
 					mainLog.Fatal().Err(err).Msg("failed to shutdown dns server for ntpd")
 				}
 			}

--- a/cmd/ctrld/cli_router.go
+++ b/cmd/ctrld/cli_router.go
@@ -1,3 +1,5 @@
+//go:build linux || freebsd
+
 package main
 
 import (

--- a/cmd/ctrld/cli_router.go
+++ b/cmd/ctrld/cli_router.go
@@ -77,6 +77,8 @@ func initRouterCLI() {
 	routerCmd.Flags().StringVarP(&logPath, "log", "", "", "Path to log file")
 	routerCmd.Flags().IntVarP(&cacheSize, "cache_size", "", 0, "Enable cache with size items")
 	routerCmd.Flags().StringVarP(&cdUID, "cd", "", "", "Control D resolver uid")
+	routerCmd.Flags().BoolVarP(&cdDev, "dev", "", false, "Use Control D dev resolver/domain")
+	_ = routerCmd.Flags().MarkHidden("dev")
 	routerCmd.Flags().StringVarP(&iface, "iface", "", "", `Update DNS setting for iface, "auto" means the default interface gateway`)
 
 	tmpl := routerCmd.UsageTemplate()

--- a/cmd/ctrld/cli_router_linux.go
+++ b/cmd/ctrld/cli_router_linux.go
@@ -43,7 +43,7 @@ func initRouterCLI() {
 				platform = router.Name()
 			}
 			switch platform {
-			case router.DDWrt, router.Merlin, router.OpenWrt, router.Ubios:
+			case router.DDWrt, router.Merlin, router.OpenWrt, router.Ubios, router.Synology:
 			default:
 				unsupportedPlatformHelp(cmd)
 				os.Exit(1)

--- a/cmd/ctrld/cli_router_linux.go
+++ b/cmd/ctrld/cli_router_linux.go
@@ -42,12 +42,11 @@ func initRouterCLI() {
 			if platform == "auto" {
 				platform = router.Name()
 			}
-			switch platform {
-			case router.DDWrt, router.Merlin, router.OpenWrt, router.Ubios, router.Synology:
-			default:
+			if !router.IsSupported(platform) {
 				unsupportedPlatformHelp(cmd)
 				os.Exit(1)
 			}
+
 			exe, err := os.Executable()
 			if err != nil {
 				mainLog.Fatal().Msgf("could not find executable path: %v", err)

--- a/cmd/ctrld/cli_router_others.go
+++ b/cmd/ctrld/cli_router_others.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !freebsd
 
 package main
 

--- a/cmd/ctrld/dns_proxy.go
+++ b/cmd/ctrld/dns_proxy.go
@@ -473,10 +473,13 @@ func runDNSServer(addr, network string, handler dns.Handler) (*dns.Server, <-cha
 // runDNSServerForNTPD starts a DNS server listening on router.ListenAddress(). It must only be called when ctrld
 // running on router, before router.PreRun() to serve DNS request for NTP synchronization. The caller must call
 // s.Shutdown() explicitly when NTP is synced successfully.
-func runDNSServerForNTPD() (*dns.Server, <-chan error) {
+func runDNSServerForNTPD(addr string) (*dns.Server, <-chan error) {
+	if addr == "" {
+		return &dns.Server{}, nil
+	}
 	dnsResolver := ctrld.NewBootstrapResolver()
 	s := &dns.Server{
-		Addr: router.ListenAddress(),
+		Addr: addr,
 		Net:  "udp",
 		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, m *dns.Msg) {
 			mainLog.Debug().Msg("Serving query for ntpd")

--- a/cmd/ctrld/dns_proxy.go
+++ b/cmd/ctrld/dns_proxy.go
@@ -470,6 +470,9 @@ func runDNSServer(addr, network string, handler dns.Handler) (*dns.Server, <-cha
 	return s, errCh
 }
 
+// runDNSServerForNTPD starts a DNS server listening on router.ListenAddress(). It must only be called when ctrld
+// running on router, before router.PreRun() to serve DNS request for NTP synchronization. The caller must call
+// s.Shutdown() explicitly when NTP is synced successfully.
 func runDNSServerForNTPD() (*dns.Server, <-chan error) {
 	dnsResolver := ctrld.NewBootstrapResolver()
 	s := &dns.Server{

--- a/cmd/ctrld/dns_proxy.go
+++ b/cmd/ctrld/dns_proxy.go
@@ -423,9 +423,19 @@ func spoofRemoteAddr(addr net.Addr, ci *ctrld.ClientInfo) net.Addr {
 	if ci != nil && ci.IP != "" {
 		switch addr := addr.(type) {
 		case *net.UDPAddr:
-			addr.IP = net.ParseIP(ci.IP)
+			udpAddr := &net.UDPAddr{
+				IP:   net.ParseIP(ci.IP),
+				Port: addr.Port,
+				Zone: addr.Zone,
+			}
+			return udpAddr
 		case *net.TCPAddr:
-			addr.IP = net.ParseIP(ci.IP)
+			udpAddr := &net.TCPAddr{
+				IP:   net.ParseIP(ci.IP),
+				Port: addr.Port,
+				Zone: addr.Zone,
+			}
+			return udpAddr
 		}
 	}
 	return addr

--- a/cmd/ctrld/dns_proxy_test.go
+++ b/cmd/ctrld/dns_proxy_test.go
@@ -174,7 +174,7 @@ func Test_macFromMsg(t *testing.T) {
 				t.Fatal(err)
 			}
 			m := new(dns.Msg)
-			m.SetQuestion(selfCheckFQDN+".", dns.TypeA)
+			m.SetQuestion("example.com.", dns.TypeA)
 			o := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
 			if tc.wantMac {
 				ec1 := &dns.EDNS0_LOCAL{Code: EDNS0_OPTION_MAC, Data: hw}

--- a/cmd/ctrld/dns_proxy_test.go
+++ b/cmd/ctrld/dns_proxy_test.go
@@ -191,3 +191,28 @@ func Test_macFromMsg(t *testing.T) {
 		})
 	}
 }
+
+func Test_remoteAddrFromMsg(t *testing.T) {
+	loopbackIP := net.ParseIP("127.0.0.1")
+	tests := []struct {
+		name string
+		addr net.Addr
+		ci   *ctrld.ClientInfo
+		want string
+	}{
+		{"tcp", &net.TCPAddr{IP: loopbackIP, Port: 12345}, &ctrld.ClientInfo{IP: "192.168.1.10"}, "192.168.1.10:12345"},
+		{"udp", &net.UDPAddr{IP: loopbackIP, Port: 12345}, &ctrld.ClientInfo{IP: "192.168.1.11"}, "192.168.1.11:12345"},
+		{"nil client info", &net.UDPAddr{IP: loopbackIP, Port: 12345}, nil, "127.0.0.1:12345"},
+		{"empty ip", &net.UDPAddr{IP: loopbackIP, Port: 12345}, &ctrld.ClientInfo{}, "127.0.0.1:12345"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			addr := spoofRemoteAddr(tc.addr, tc.ci)
+			if addr.String() != tc.want {
+				t.Errorf("unexpected result, want: %q, got: %q", tc.want, addr.String())
+			}
+		})
+	}
+}

--- a/cmd/ctrld/main.go
+++ b/cmd/ctrld/main.go
@@ -27,6 +27,7 @@ var (
 	verbose           int
 	silent            bool
 	cdUID             string
+	cdDev             bool
 	iface             string
 	ifaceStartStop    string
 	setupRouter       bool

--- a/cmd/ctrld/prog.go
+++ b/cmd/ctrld/prog.go
@@ -175,7 +175,7 @@ func (p *prog) setDNS() {
 	switch router.Name() {
 	case router.DDWrt, router.OpenWrt, router.Ubios:
 		// On router, ctrld run as a DNS forwarder, it does not have to change system DNS.
-		// Except for Merlin, which has WAN DNS setup on boot for NTP.
+		// Except for Merlin/Tomato, which has WAN DNS setup on boot for NTP.
 		return
 	}
 	if cfg.Listener == nil || cfg.Listener["0"] == nil {

--- a/cmd/ctrld/prog.go
+++ b/cmd/ctrld/prog.go
@@ -175,7 +175,10 @@ func (p *prog) setDNS() {
 	switch router.Name() {
 	case router.DDWrt, router.OpenWrt, router.Ubios:
 		// On router, ctrld run as a DNS forwarder, it does not have to change system DNS.
-		// Except for Merlin/Tomato, which has WAN DNS setup on boot for NTP.
+		// Except for:
+		//   + EdgeOS, which /etc/resolv.conf could be managed by vyatta_update_resolv.pl script.
+		//   + Merlin/Tomato, which has WAN DNS setup on boot for NTP.
+		//   + Synology, which /etc/resolv.conf is not configured to point to localhost.
 		return
 	}
 	if cfg.Listener == nil || cfg.Listener["0"] == nil {

--- a/cmd/ctrld/prog_linux.go
+++ b/cmd/ctrld/prog_linux.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"github.com/kardianos/service"
+
+	"github.com/Control-D-Inc/ctrld/internal/router"
 )
 
 func (p *prog) preRun() {
@@ -16,6 +18,13 @@ func setDependencies(svc *service.Config) {
 		"After=network-online.target",
 		"Wants=NetworkManager-wait-online.service",
 		"After=NetworkManager-wait-online.service",
+	}
+	// On EdeOS, ctrld needs to start after vyatta-dhcpd, so it can read leases file.
+	if router.Name() == router.EdgeOS {
+		svc.Dependencies = append(svc.Dependencies, "Wants=vyatta-dhcpd.service")
+		svc.Dependencies = append(svc.Dependencies, "After=vyatta-dhcpd.service")
+		svc.Dependencies = append(svc.Dependencies, "Wants=dnsmasq.service")
+		svc.Dependencies = append(svc.Dependencies, "After=dnsmasq.service")
 	}
 }
 

--- a/cmd/ctrld/service.go
+++ b/cmd/ctrld/service.go
@@ -13,7 +13,8 @@ import (
 
 func newService(s service.Service) service.Service {
 	// TODO: unify for other SysV system.
-	if router.IsGLiNet() {
+	switch {
+	case router.IsGLiNet(), router.IsOldOpenwrt():
 		return &sysV{s}
 	}
 	return s

--- a/config.go
+++ b/config.go
@@ -24,10 +24,17 @@ import (
 	ctrldnet "github.com/Control-D-Inc/ctrld/internal/net"
 )
 
+// IpStackBoth ...
 const (
-	IpStackBoth  = "both"
-	IpStackV4    = "v4"
-	IpStackV6    = "v6"
+	// IpStackBoth indicates that ctrld will use either ipv4 or ipv6 for connecting to upstream,
+	// depending on which stack is available when receiving the DNS query.
+	IpStackBoth = "both"
+	// IpStackV4 indicates that ctrld will use only ipv4 for connecting to upstream.
+	IpStackV4 = "v4"
+	// IpStackV6 indicates that ctrld will use only ipv6 for connecting to upstream.
+	IpStackV6 = "v6"
+	// IpStackSplit indicates that ctrld will use either ipv4 or ipv6 for connecting to upstream,
+	// depending on the record type of the DNS query.
 	IpStackSplit = "split"
 
 	controlDComDomain = "controld.com"
@@ -251,6 +258,7 @@ func (uc *UpstreamConfig) UpstreamSendClientInfo() bool {
 	return false
 }
 
+// BootstrapIPs returns the bootstrap IPs list of upstreams.
 func (uc *UpstreamConfig) BootstrapIPs() []string {
 	return uc.bootstrapIPs
 }

--- a/config.go
+++ b/config.go
@@ -347,9 +347,7 @@ func (uc *UpstreamConfig) setupDOHTransportWithoutPingUpstream() {
 		uc.transport = uc.newDOHTransport(uc.bootstrapIPs6)
 	case IpStackSplit:
 		uc.transport4 = uc.newDOHTransport(uc.bootstrapIPs4)
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		if ctrldnet.IPv6Available(ctx) {
+		if hasIPv6() {
 			uc.transport6 = uc.newDOHTransport(uc.bootstrapIPs6)
 		} else {
 			uc.transport6 = uc.transport4
@@ -419,7 +417,10 @@ func (uc *UpstreamConfig) bootstrapIPForDNSType(dnsType uint16) string {
 		case dns.TypeA:
 			return pick(uc.bootstrapIPs4)
 		default:
-			return pick(uc.bootstrapIPs6)
+			if hasIPv6() {
+				return pick(uc.bootstrapIPs6)
+			}
+			return pick(uc.bootstrapIPs4)
 		}
 	}
 	return pick(uc.bootstrapIPs)
@@ -438,7 +439,10 @@ func (uc *UpstreamConfig) netForDNSType(dnsType uint16) (string, string) {
 		case dns.TypeA:
 			return "tcp4-tls", "udp4"
 		default:
-			return "tcp6-tls", "udp6"
+			if hasIPv6() {
+				return "tcp6-tls", "udp6"
+			}
+			return "tcp4-tls", "udp4"
 		}
 	}
 	return "tcp-tls", "udp"

--- a/config_internal_test.go
+++ b/config_internal_test.go
@@ -190,6 +190,39 @@ func TestUpstreamConfig_Init(t *testing.T) {
 	}
 }
 
+func TestUpstreamConfig_VerifyDomain(t *testing.T) {
+	tests := []struct {
+		name         string
+		uc           *UpstreamConfig
+		verifyDomain string
+	}{
+		{
+			controlDComDomain,
+			&UpstreamConfig{Endpoint: "https://freedns.controld.com/p2"},
+			controldVerifiedDomain[controlDComDomain],
+		},
+		{
+			controlDDevDomain,
+			&UpstreamConfig{Endpoint: "https://freedns.controld.dev/p2"},
+			controldVerifiedDomain[controlDDevDomain],
+		},
+		{
+			"non-ControlD upstream",
+			&UpstreamConfig{Endpoint: "https://dns.google/dns-query"},
+			"",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.uc.VerifyDomain(); got != tc.verifyDomain {
+				t.Errorf("unexpected verify domain, want: %q, got: %q", tc.verifyDomain, got)
+			}
+		})
+	}
+}
 func ptrBool(b bool) *bool {
 	return &b
 }

--- a/config_quic.go
+++ b/config_quic.go
@@ -109,6 +109,7 @@ type parallelDialerResult struct {
 
 type quicParallelDialer struct{}
 
+// Dial performs parallel dialing to the given address list.
 func (d *quicParallelDialer) Dial(ctx context.Context, domain string, addrs []string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
 	if len(addrs) == 0 {
 		return nil, errors.New("empty addresses")

--- a/doh.go
+++ b/doh.go
@@ -13,10 +13,9 @@ import (
 )
 
 const (
-	DoHMacHeader  = "x-cd-mac"
-	DoHIPHeader   = "x-cd-ip"
-	DoHHostHeader = "x-cd-host"
-
+	dohMacHeader         = "x-cd-mac"
+	dohIPHeader          = "x-cd-ip"
+	dohHostHeader        = "x-cd-host"
 	headerApplicationDNS = "application/dns-message"
 )
 
@@ -101,13 +100,13 @@ func addHeader(ctx context.Context, req *http.Request, sendClientInfo bool) {
 	if sendClientInfo {
 		if ci, ok := ctx.Value(ClientInfoCtxKey{}).(*ClientInfo); ok && ci != nil {
 			if ci.Mac != "" {
-				req.Header.Set(DoHMacHeader, ci.Mac)
+				req.Header.Set(dohMacHeader, ci.Mac)
 			}
 			if ci.IP != "" {
-				req.Header.Set(DoHIPHeader, ci.IP)
+				req.Header.Set(dohIPHeader, ci.IP)
 			}
 			if ci.Hostname != "" {
-				req.Header.Set(DoHHostHeader, ci.Hostname)
+				req.Header.Set(dohHostHeader, ci.Hostname)
 			}
 		}
 	}

--- a/dot.go
+++ b/dot.go
@@ -33,6 +33,7 @@ func (r *dotResolver) Resolve(ctx context.Context, msg *dns.Msg) (*dns.Msg, erro
 	endpoint := r.uc.Endpoint
 	if r.uc.BootstrapIP != "" {
 		dnsClient.TLSConfig.ServerName = r.uc.Domain
+		dnsClient.Net = "tcp-tls"
 		_, port, _ := net.SplitHostPort(endpoint)
 		endpoint = net.JoinHostPort(r.uc.BootstrapIP, port)
 	}

--- a/internal/controld/config_test.go
+++ b/internal/controld/config_test.go
@@ -13,16 +13,18 @@ func TestFetchResolverConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		uid     string
+		dev     bool
 		wantErr bool
 	}{
-		{"valid", "p2", false},
-		{"invalid uid", "abcd1234", true},
+		{"valid com", "p2", false, false},
+		{"valid dev", "p2", true, false},
+		{"invalid uid", "abcd1234", false, true},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := FetchResolverConfig(tc.uid, "dev-test")
+			got, err := FetchResolverConfig(tc.uid, "dev-test", tc.dev)
 			require.False(t, (err != nil) != tc.wantErr, err)
 			if !tc.wantErr {
 				assert.NotEmpty(t, got.DOH)

--- a/internal/router/client_info.go
+++ b/internal/router/client_info.go
@@ -21,6 +21,7 @@ var clientInfoFiles = []string{
 	"/var/lib/misc/dnsmasq.leases",         // merlin
 	"/mnt/data/udapi-config/dnsmasq.lease", // UDM Pro
 	"/data/udapi-config/dnsmasq.lease",     // UDR
+	"/etc/dhcpd/dhcpd-leases.log",          // Synology
 }
 
 func (r *router) watchClientInfoTable() {

--- a/internal/router/client_info.go
+++ b/internal/router/client_info.go
@@ -28,6 +28,7 @@ var clientInfoFiles = map[string]readClientInfoFunc{
 	"/tmp/var/lib/misc/dnsmasq.leases":     dnsmasqReadClientInfoFile, // Tomato
 	"/run/dnsmasq-dhcp.leases":             dnsmasqReadClientInfoFile, // EdgeOS
 	"/run/dhcpd.leases":                    iscDHCPReadClientInfoFile, // EdgeOS
+	"/var/dhcpd/var/db/dhcpd.leases":       iscDHCPReadClientInfoFile, // Pfsense
 }
 
 func (r *router) watchClientInfoTable() {

--- a/internal/router/client_info.go
+++ b/internal/router/client_info.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"log"
@@ -15,14 +16,18 @@ import (
 	"github.com/Control-D-Inc/ctrld"
 )
 
-var clientInfoFiles = []string{
-	"/tmp/dnsmasq.leases",                  // ddwrt
-	"/tmp/dhcp.leases",                     // openwrt
-	"/var/lib/misc/dnsmasq.leases",         // merlin
-	"/mnt/data/udapi-config/dnsmasq.lease", // UDM Pro
-	"/data/udapi-config/dnsmasq.lease",     // UDR
-	"/etc/dhcpd/dhcpd-leases.log",          // Synology
-	"/tmp/var/lib/misc/dnsmasq.leases",     // Tomato
+type readClientInfoFunc func(name string) error
+
+var clientInfoFiles = map[string]readClientInfoFunc{
+	"/tmp/dnsmasq.leases":                  dnsmasqReadClientInfoFile, // ddwrt
+	"/tmp/dhcp.leases":                     dnsmasqReadClientInfoFile, // openwrt
+	"/var/lib/misc/dnsmasq.leases":         dnsmasqReadClientInfoFile, // merlin
+	"/mnt/data/udapi-config/dnsmasq.lease": dnsmasqReadClientInfoFile, // UDM Pro
+	"/data/udapi-config/dnsmasq.lease":     dnsmasqReadClientInfoFile, // UDR
+	"/etc/dhcpd/dhcpd-leases.log":          dnsmasqReadClientInfoFile, // Synology
+	"/tmp/var/lib/misc/dnsmasq.leases":     dnsmasqReadClientInfoFile, // Tomato
+	"/run/dnsmasq-dhcp.leases":             dnsmasqReadClientInfoFile, // EdgeOS
+	"/run/dhcpd.leases":                    iscDHCPReadClientInfoFile, // EdgeOS
 }
 
 func (r *router) watchClientInfoTable() {
@@ -34,14 +39,19 @@ func (r *router) watchClientInfoTable() {
 		select {
 		case <-timer.C:
 			for _, name := range r.watcher.WatchList() {
-				_ = readClientInfoFile(name)
+				_ = clientInfoFiles[name](name)
 			}
 		case event, ok := <-r.watcher.Events:
 			if !ok {
 				return
 			}
 			if event.Has(fsnotify.Write) {
-				if err := readClientInfoFile(event.Name); err != nil && !os.IsNotExist(err) {
+				readFunc := clientInfoFiles[event.Name]
+				if readFunc == nil {
+					log.Println("unknown file format:", event.Name)
+					continue
+				}
+				if err := readFunc(event.Name); err != nil && !os.IsNotExist(err) {
 					log.Println("could not read client info file:", err)
 				}
 			}
@@ -80,17 +90,17 @@ func GetClientInfoByMac(mac string) *ctrld.ClientInfo {
 	return val.(*ctrld.ClientInfo)
 }
 
-func readClientInfoFile(name string) error {
+func dnsmasqReadClientInfoFile(name string) error {
 	f, err := os.Open(name)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	return readClientInfoReader(f)
+	return dnsmasqReadClientInfoReader(f)
 
 }
 
-func readClientInfoReader(reader io.Reader) error {
+func dnsmasqReadClientInfoReader(reader io.Reader) error {
 	r := routerPlatform.Load()
 	return lineread.Reader(reader, func(line []byte) error {
 		fields := bytes.Fields(line)
@@ -111,6 +121,54 @@ func readClientInfoReader(reader io.Reader) error {
 		r.mac.Store(mac, &ctrld.ClientInfo{Mac: mac, IP: ip, Hostname: hostname})
 		return nil
 	})
+}
+
+func iscDHCPReadClientInfoFile(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return iscDHCPReadClientInfoReader(f)
+}
+
+func iscDHCPReadClientInfoReader(reader io.Reader) error {
+	r := routerPlatform.Load()
+	s := bufio.NewScanner(reader)
+	var ip, mac, hostname string
+	for s.Scan() {
+		line := s.Text()
+		if strings.HasPrefix(line, "}") {
+			if mac != "" {
+				r.mac.Store(mac, &ctrld.ClientInfo{Mac: mac, IP: ip, Hostname: hostname})
+				ip, mac, hostname = "", "", ""
+			}
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "lease":
+			ip = normalizeIP(strings.ToLower(fields[1]))
+			if net.ParseIP(ip) == nil {
+				log.Printf("invalid ip address entry: %q", ip)
+				ip = ""
+			}
+		case "hardware":
+			if len(fields) >= 3 {
+				mac = strings.ToLower(strings.TrimRight(fields[2], ";"))
+				if _, err := net.ParseMAC(mac); err != nil {
+					// Invalid mac, skip.
+					mac = ""
+				}
+			}
+		case "client-hostname":
+			hostname = strings.Trim(fields[1], `";`)
+		}
+	}
+	return nil
 }
 
 func normalizeIP(in string) string {

--- a/internal/router/client_info.go
+++ b/internal/router/client_info.go
@@ -22,6 +22,7 @@ var clientInfoFiles = []string{
 	"/mnt/data/udapi-config/dnsmasq.lease", // UDM Pro
 	"/data/udapi-config/dnsmasq.lease",     // UDR
 	"/etc/dhcpd/dhcpd-leases.log",          // Synology
+	"/tmp/var/lib/misc/dnsmasq.leases",     // Tomato
 }
 
 func (r *router) watchClientInfoTable() {

--- a/internal/router/client_info.go
+++ b/internal/router/client_info.go
@@ -105,7 +105,7 @@ func dnsmasqReadClientInfoReader(reader io.Reader) error {
 	r := routerPlatform.Load()
 	return lineread.Reader(reader, func(line []byte) error {
 		fields := bytes.Fields(line)
-		if len(fields) != 5 {
+		if len(fields) < 4 {
 			return nil
 		}
 		mac := string(fields[1])

--- a/internal/router/client_info_test.go
+++ b/internal/router/client_info_test.go
@@ -78,6 +78,12 @@ lease 192.168.1.2 {
 			iscDHCPReadClientInfoReader,
 			"00:00:00:00:00:02",
 		},
+		{
+			"",
+			`1685794060 00:00:00:00:00:04 192.168.0.209 cuonglm-ThinkPad-X1-Carbon-Gen-9 00:00:00:00:00:04 9`,
+			dnsmasqReadClientInfoReader,
+			"00:00:00:00:00:04",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/router/client_info_test.go
+++ b/internal/router/client_info_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -31,23 +32,51 @@ func Test_normalizeIP(t *testing.T) {
 
 func Test_readClientInfoReader(t *testing.T) {
 	tests := []struct {
-		name string
-		in   string
-		mac  string
+		name     string
+		in       string
+		readFunc func(r io.Reader) error
+		mac      string
 	}{
 		{
-			"good",
+			"good dnsmasq",
 			`1683329857 e6:20:59:b8:c1:6d 192.168.1.186 * 01:e6:20:59:b8:c1:6d
 `,
+			dnsmasqReadClientInfoReader,
 			"e6:20:59:b8:c1:6d",
 		},
 		{
-			"bad seen on UDMdream machine",
+			"bad dnsmasq seen on UDMdream machine",
 			`1683329857 e6:20:59:b8:c1:6e 192.168.1.111 * 01:e6:20:59:b8:c1:6e
 duid 00:01:00:01:2b:e4:2e:2c:52:52:14:26:dc:1c
 1683322985 117442354 2600:4040:b0e6:b700::111 ASDASD 00:01:00:01:2a:d0:b9:81:00:07:32:4c:1c:07
 `,
+			dnsmasqReadClientInfoReader,
 			"e6:20:59:b8:c1:6e",
+		},
+		{
+			"isc-dhcpd good",
+			`lease 192.168.1.1 {
+    hardware ethernet 00:00:00:00:00:01;
+    client-hostname "host-1";
+}
+`,
+			iscDHCPReadClientInfoReader,
+			"00:00:00:00:00:01",
+		},
+		{
+			"isc-dhcpd bad mac",
+			`lease 192.168.1.1 {
+    hardware ethernet invalid-mac;
+    client-hostname "host-1";
+}
+
+lease 192.168.1.2 {
+    hardware ethernet 00:00:00:00:00:02;
+    client-hostname "host-2";
+}
+`,
+			iscDHCPReadClientInfoReader,
+			"00:00:00:00:00:02",
 		},
 	}
 
@@ -55,7 +84,7 @@ duid 00:01:00:01:2b:e4:2e:2c:52:52:14:26:dc:1c
 		t.Run(tc.name, func(t *testing.T) {
 			r := routerPlatform.Load()
 			r.mac.Delete(tc.mac)
-			if err := readClientInfoReader(strings.NewReader(tc.in)); err != nil {
+			if err := tc.readFunc(strings.NewReader(tc.in)); err != nil {
 				t.Errorf("readClientInfoReader() error = %v", err)
 			}
 			info, existed := r.mac.Load(tc.mac)
@@ -64,6 +93,8 @@ duid 00:01:00:01:2b:e4:2e:2c:52:52:14:26:dc:1c
 			}
 			if ci, ok := info.(*ctrld.ClientInfo); ok && existed && ci.Mac != tc.mac {
 				t.Errorf("mac mismatched, got: %q, want: %q", ci.Mac, tc.mac)
+			} else {
+				t.Log(ci)
 			}
 		})
 	}

--- a/internal/router/ddwrt.go
+++ b/internal/router/ddwrt.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	nvramCtrldKeyPrefix = "ctrld_"
-	nvramCtrldSetupKey  = "ctrld_setup"
-	nvramRCStartupKey   = "rc_startup"
+	nvramCtrldKeyPrefix  = "ctrld_"
+	nvramCtrldSetupKey   = "ctrld_setup"
+	nvramCtrldInstallKey = "ctrld_install"
+	nvramRCStartupKey    = "rc_startup"
 )
 
 //lint:ignore ST1005 This error is for human.
@@ -29,14 +30,14 @@ func setupDDWrt() error {
 		return err
 	}
 
-	nvramKvMap := nvramKV()
+	nvramKvMap := nvramSetupKV()
 	nvramKvMap["dnsmasq_options"] = data
-	if err := nvramSetup(nvramKvMap); err != nil {
+	if err := nvramSetKV(nvramKvMap, nvramCtrldSetupKey); err != nil {
 		return err
 	}
 
 	// Restart dnsmasq service.
-	if err := ddwrtRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil
@@ -44,11 +45,11 @@ func setupDDWrt() error {
 
 func cleanupDDWrt() error {
 	// Restore old configs.
-	if err := nvramRestore(nvramKV()); err != nil {
+	if err := nvramRestore(nvramSetupKV(), nvramCtrldSetupKey); err != nil {
 		return err
 	}
 	// Restart dnsmasq service.
-	if err := ddwrtRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil

--- a/internal/router/dnsmasq.go
+++ b/internal/router/dnsmasq.go
@@ -49,7 +49,7 @@ func dnsMasqConf() (string, error) {
 	var sb strings.Builder
 	var tmplText string
 	switch Name() {
-	case DDWrt, OpenWrt, Ubios, Synology, Tomato:
+	case EdgeOS, DDWrt, OpenWrt, Ubios, Synology, Tomato:
 		tmplText = dnsMasqConfigContentTmpl
 	case Merlin:
 		tmplText = merlinDNSMasqPostConfTmpl
@@ -68,6 +68,8 @@ func dnsMasqConf() (string, error) {
 
 func restartDNSMasq() error {
 	switch Name() {
+	case EdgeOS:
+		return edgeOSRestartDNSMasq()
 	case DDWrt:
 		return ddwrtRestartDNSMasq()
 	case Merlin:

--- a/internal/router/dnsmasq.go
+++ b/internal/router/dnsmasq.go
@@ -49,7 +49,7 @@ func dnsMasqConf() (string, error) {
 	var sb strings.Builder
 	var tmplText string
 	switch Name() {
-	case DDWrt, OpenWrt, Ubios:
+	case DDWrt, OpenWrt, Ubios, Synology:
 		tmplText = dnsMasqConfigContentTmpl
 	case Merlin:
 		tmplText = merlinDNSMasqPostConfTmpl

--- a/internal/router/dnsmasq.go
+++ b/internal/router/dnsmasq.go
@@ -49,7 +49,7 @@ func dnsMasqConf() (string, error) {
 	var sb strings.Builder
 	var tmplText string
 	switch Name() {
-	case DDWrt, OpenWrt, Ubios, Synology:
+	case DDWrt, OpenWrt, Ubios, Synology, Tomato:
 		tmplText = dnsMasqConfigContentTmpl
 	case Merlin:
 		tmplText = merlinDNSMasqPostConfTmpl
@@ -64,4 +64,22 @@ func dnsMasqConf() (string, error) {
 		return "", err
 	}
 	return sb.String(), nil
+}
+
+func restartDNSMasq() error {
+	switch Name() {
+	case DDWrt:
+		return ddwrtRestartDNSMasq()
+	case Merlin:
+		return merlinRestartDNSMasq()
+	case OpenWrt:
+		return openwrtRestartDNSMasq()
+	case Ubios:
+		return ubiosRestartDNSMasq()
+	case Synology:
+		return synologyRestartDNSMasq()
+	case Tomato:
+		return tomatoRestartService(tomatoDNSMasqSvcName)
+	}
+	panic("not supported platform")
 }

--- a/internal/router/edgeos.go
+++ b/internal/router/edgeos.go
@@ -37,6 +37,14 @@ func cleanupEdgeOS() error {
 }
 
 func postInstallEdgeOS() error {
+	// If "Content Filtering" is enabled, UniFi OS will create firewall rules to intercept all DNS queries
+	// from outside, and route those queries to separated interfaces (e.g: dnsfilter-2@if79) created by UniFi OS.
+	// Thus, those queries will never reach ctrld listener. UniFi OS does not provide any mechanism to toggle this
+	// feature via command line, so there's nothing ctrld can do to disable this feature. For now, reporting an
+	// error and guiding users to disable the feature using UniFi OS web UI.
+	if contentFilteringEnabled() {
+		return errContentFilteringEnabled
+	}
 	return nil
 }
 

--- a/internal/router/edgeos.go
+++ b/internal/router/edgeos.go
@@ -1,0 +1,48 @@
+package router
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const edgeOSDNSMasqConfigPath = "/etc/dnsmasq.d/dnsmasq-zzz-ctrld.conf"
+
+func setupEdgeOS() error {
+	// Disable dnsmasq as DNS server.
+	dnsMasqConfigContent, err := dnsMasqConf()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(edgeOSDNSMasqConfigPath, []byte(dnsMasqConfigContent), 0600); err != nil {
+		return err
+	}
+	// Restart dnsmasq service.
+	if err := restartDNSMasq(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupEdgeOS() error {
+	// Remove the custom dnsmasq config
+	if err := os.Remove(edgeOSDNSMasqConfigPath); err != nil {
+		return err
+	}
+	// Restart dnsmasq service.
+	if err := restartDNSMasq(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func postInstallEdgeOS() error {
+	return nil
+}
+
+func edgeOSRestartDNSMasq() error {
+	if out, err := exec.Command("/etc/init.d/dnsmasq", "restart").CombinedOutput(); err != nil {
+		return fmt.Errorf("edgeosRestartDNSMasq: %s, %w", string(out), err)
+	}
+	return nil
+}

--- a/internal/router/merlin.go
+++ b/internal/router/merlin.go
@@ -2,11 +2,16 @@ package router
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 	"unicode"
+
+	"tailscale.com/logtail/backoff"
 )
 
 func setupMerlin() error {
@@ -35,11 +40,11 @@ func setupMerlin() error {
 		return err
 	}
 	// Restart dnsmasq service.
-	if err := merlinRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 
-	if err := nvramSetup(nvramKV()); err != nil {
+	if err := nvramSetKV(nvramSetupKV(), nvramCtrldSetupKey); err != nil {
 		return err
 	}
 
@@ -48,7 +53,7 @@ func setupMerlin() error {
 
 func cleanupMerlin() error {
 	// Restore old configs.
-	if err := nvramRestore(nvramKV()); err != nil {
+	if err := nvramRestore(nvramSetupKV(), nvramCtrldSetupKey); err != nil {
 		return err
 	}
 	buf, err := os.ReadFile(merlinDNSMasqPostConfPath)
@@ -60,7 +65,7 @@ func cleanupMerlin() error {
 		return err
 	}
 	// Restart dnsmasq service.
-	if err := merlinRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil
@@ -86,4 +91,44 @@ func merlinParsePostConf(buf []byte) []byte {
 		return bytes.TrimLeftFunc(parts[1], unicode.IsSpace)
 	}
 	return buf
+}
+
+func merlinPreStart() (err error) {
+	pidFile := "/tmp/ctrld.pid"
+
+	// Remove pid file and trigger dnsmasq restart, so NTP can resolve
+	// server name and perform time synchronization.
+	pid, err := os.ReadFile(pidFile)
+	if err != nil {
+		return fmt.Errorf("PreStart: os.Readfile: %w", err)
+	}
+	if err := os.Remove(pidFile); err != nil {
+		return fmt.Errorf("PreStart: os.Remove: %w", err)
+	}
+	defer func() {
+		if werr := os.WriteFile(pidFile, pid, 0600); werr != nil {
+			err = errors.Join(err, werr)
+			return
+		}
+		if rerr := restartDNSMasq(); rerr != nil {
+			err = errors.Join(err, rerr)
+			return
+		}
+	}()
+	if err := restartDNSMasq(); err != nil {
+		return fmt.Errorf("PreStart: restartDNSMasqFn: %w", err)
+	}
+
+	// Wait until `ntp_ready=1` set.
+	b := backoff.NewBackoff("PreStart", func(format string, args ...any) {}, 10*time.Second)
+	for {
+		out, err := nvram("get", "ntp_ready")
+		if err != nil {
+			return fmt.Errorf("PreStart: nvram: %w", err)
+		}
+		if out == "1" {
+			return nil
+		}
+		b.BackOff(context.Background(), errors.New("ntp not ready"))
+	}
 }

--- a/internal/router/openwrt.go
+++ b/internal/router/openwrt.go
@@ -28,7 +28,6 @@ func setupOpenWrt() error {
 	if _, err := uci("delete", "dhcp.@dnsmasq[0].port"); err != nil && !errors.Is(err, errUCIEntryNotFound) {
 		return err
 	}
-	// Disable dnsmasq as DNS server.
 	dnsMasqConfigContent, err := dnsMasqConf()
 	if err != nil {
 		return err

--- a/internal/router/openwrt.go
+++ b/internal/router/openwrt.go
@@ -40,7 +40,7 @@ func setupOpenWrt() error {
 		return err
 	}
 	// Restart dnsmasq service.
-	if err := openwrtRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil
@@ -52,7 +52,7 @@ func cleanupOpenWrt() error {
 		return err
 	}
 	// Restart dnsmasq service.
-	if err := openwrtRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil

--- a/internal/router/openwrt.go
+++ b/internal/router/openwrt.go
@@ -23,6 +23,16 @@ func IsGLiNet() bool {
 	return bytes.Contains(buf, []byte(" (glinet"))
 }
 
+// IsOldOpenwrt reports whether the router is an "old" version of Openwrt,
+// aka versions which don't have "service" command.
+func IsOldOpenwrt() bool {
+	if Name() != OpenWrt {
+		return false
+	}
+	cmd, _ := exec.LookPath("service")
+	return cmd == ""
+}
+
 func setupOpenWrt() error {
 	// Delete dnsmasq port if set.
 	if _, err := uci("delete", "dhcp.@dnsmasq[0].port"); err != nil && !errors.Is(err, errUCIEntryNotFound) {

--- a/internal/router/pfsense.go
+++ b/internal/router/pfsense.go
@@ -1,0 +1,56 @@
+package router
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kardianos/service"
+)
+
+const (
+	rcPath        = "/usr/local/etc/rc.d"
+	unboundRcPath = rcPath + "/unbound"
+)
+
+func setupPfsense() error {
+	// If Pfsense is in DNS Resolver mode, ensure no unbound processes running.
+	if _, err := exec.Command("service", "unbound", "onestatus").CombinedOutput(); err == nil {
+		if out, err := exec.Command("killall", "unbound").CombinedOutput(); err != nil {
+			return fmt.Errorf("could not killall unbound: %s: %w", string(out), err)
+		}
+	}
+	// If Pfsense is in DNS Forwarder mode, ensure no dnsmasq processes running.
+	if _, err := exec.Command("service", "dnsmasq", "onestatus").CombinedOutput(); err == nil {
+		if out, err := exec.Command("killall", "dnsmasq").CombinedOutput(); err != nil {
+			return fmt.Errorf("could not killall unbound: %s: %w", string(out), err)
+		}
+	}
+	return nil
+}
+
+func cleanupPfsense(svc *service.Config) error {
+	if err := os.Remove(filepath.Join(rcPath, svc.Name+".sh")); err != nil {
+		return fmt.Errorf("os.Remove: %w", err)
+	}
+	if out, err := exec.Command(unboundRcPath, "onerestart").CombinedOutput(); err != nil {
+		return fmt.Errorf("could not restart unbound: %s: %w", string(out), err)
+	}
+	if out, err := exec.Command(unboundRcPath, "onerestart").CombinedOutput(); err != nil {
+		return fmt.Errorf("could not restart unbound: %s: %w", string(out), err)
+	}
+	return nil
+}
+
+func postInstallPfsense(svc *service.Config) error {
+	// pfsense need ".sh" extension for script to be run at boot.
+	// See: https://docs.netgate.com/pfsense/en/latest/development/boot-commands.html#shell-script-option
+	oldname := filepath.Join(rcPath, svc.Name)
+	newname := filepath.Join(rcPath, svc.Name+".sh")
+	_ = os.Remove(newname)
+	if err := os.Symlink(oldname, newname); err != nil {
+		return fmt.Errorf("os.Symlink: %w", err)
+	}
+	return nil
+}

--- a/internal/router/pfsense.go
+++ b/internal/router/pfsense.go
@@ -20,7 +20,7 @@ func setupPfsense() error {
 	_ = exec.Command("killall", "unbound").Run()
 
 	// If Pfsense is in DNS Forwarder mode, ensure no dnsmasq processes running.
-	_ = exec.Command("killall", "dnsmasq")
+	_ = exec.Command("killall", "dnsmasq").Run()
 	return nil
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -105,7 +105,9 @@ func ConfigureService(sc *service.Config) error {
 		}
 	case OpenWrt:
 		sc.Option["SysvScript"] = openWrtScript
-	case EdgeOS, Merlin, Pfsense, Synology, Tomato, Ubios:
+	case Pfsense:
+		sc.Option["SysvScript"] = pfsenseInitScript
+	case EdgeOS, Merlin, Synology, Tomato, Ubios:
 	}
 	return nil
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -95,7 +95,7 @@ func ConfigureService(sc *service.Config) error {
 
 // PreStart blocks until the router is ready for running ctrld.
 func PreStart() (err error) {
-	if Name() != DDWrt {
+	if Name() != Merlin {
 		return nil
 	}
 

--- a/internal/router/service.go
+++ b/internal/router/service.go
@@ -48,6 +48,15 @@ func init() {
 			},
 			new: newUbiosService,
 		},
+		&linuxSystemService{
+			name:   "tomato",
+			detect: func() bool { return Name() == Tomato },
+			interactive: func() bool {
+				is, _ := isInteractive()
+				return is
+			},
+			new: newTomatoService,
+		},
 	}
 	systems = append(systems, service.AvailableSystems()...)
 	service.ChooseSystem(systems...)

--- a/internal/router/service_tomato.go
+++ b/internal/router/service_tomato.go
@@ -1,0 +1,278 @@
+package router
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/template"
+
+	"github.com/kardianos/service"
+)
+
+const tomatoNvramScriptWanupKey = "script_wanup"
+
+type tomatoSvc struct {
+	i        service.Interface
+	platform string
+	*service.Config
+}
+
+func newTomatoService(i service.Interface, platform string, c *service.Config) (service.Service, error) {
+	s := &tomatoSvc{
+		i:        i,
+		platform: platform,
+		Config:   c,
+	}
+	return s, nil
+}
+
+func (s *tomatoSvc) String() string {
+	if len(s.DisplayName) > 0 {
+		return s.DisplayName
+	}
+	return s.Name
+}
+
+func (s *tomatoSvc) Platform() string {
+	return s.platform
+}
+
+func (s *tomatoSvc) configPath() string {
+	path, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return path + ".startup"
+}
+
+func (s *tomatoSvc) template() *template.Template {
+	return template.Must(template.New("").Parse(tomatoSvcScript))
+}
+
+func (s *tomatoSvc) Install() error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(exePath, "/jffs/") {
+		return errors.New("could not install service outside /jffs")
+	}
+	if _, err := nvram("set", "jffs2_on=1"); err != nil {
+		return err
+	}
+	if _, err := nvram("commit"); err != nil {
+		return err
+	}
+
+	confPath := s.configPath()
+	if _, err := os.Stat(confPath); err == nil {
+		return fmt.Errorf("already installed: %s", confPath)
+	}
+
+	var to = &struct {
+		*service.Config
+		Path string
+	}{
+		s.Config,
+		exePath,
+	}
+
+	f, err := os.Create(confPath)
+	if err != nil {
+		return fmt.Errorf("os.Create: %w", err)
+	}
+	defer f.Close()
+
+	if err := s.template().Execute(f, to); err != nil {
+		return fmt.Errorf("s.template.Execute: %w", err)
+	}
+
+	if err = os.Chmod(confPath, 0755); err != nil {
+		return fmt.Errorf("os.Chmod: startup script: %w", err)
+	}
+
+	nvramKvMap := nvramInstallKV()
+	old, err := nvram("get", tomatoNvramScriptWanupKey)
+	if err != nil {
+		return fmt.Errorf("nvram: %w", err)
+	}
+	nvramKvMap[tomatoNvramScriptWanupKey] = strings.Join([]string{old, s.configPath() + " start"}, "\n")
+	if err := nvramSetKV(nvramKvMap, nvramCtrldInstallKey); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *tomatoSvc) Uninstall() error {
+	if err := os.Remove(s.configPath()); err != nil {
+		return fmt.Errorf("os.Remove: %w", err)
+	}
+	// Restore old configs.
+	if err := nvramRestore(nvramInstallKV(), nvramCtrldInstallKey); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *tomatoSvc) Logger(errs chan<- error) (service.Logger, error) {
+	if service.Interactive() {
+		return service.ConsoleLogger, nil
+	}
+	return s.SystemLogger(errs)
+}
+
+func (s *tomatoSvc) SystemLogger(errs chan<- error) (service.Logger, error) {
+	return newSysLogger(s.Name, errs)
+}
+
+func (s *tomatoSvc) Run() (err error) {
+	err = s.i.Start(s)
+	if err != nil {
+		return err
+	}
+
+	if interactice, _ := isInteractive(); !interactice {
+		signal.Ignore(syscall.SIGHUP)
+	}
+
+	var sigChan = make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
+	<-sigChan
+
+	return s.i.Stop(s)
+}
+
+func (s *tomatoSvc) Status() (service.Status, error) {
+	if _, err := os.Stat(s.configPath()); os.IsNotExist(err) {
+		return service.StatusUnknown, service.ErrNotInstalled
+	}
+	out, err := exec.Command(s.configPath(), "status").CombinedOutput()
+	if err != nil {
+		return service.StatusUnknown, err
+	}
+	switch string(bytes.TrimSpace(out)) {
+	case "running":
+		return service.StatusRunning, nil
+	default:
+		return service.StatusStopped, nil
+	}
+}
+
+func (s *tomatoSvc) Start() error {
+	return exec.Command(s.configPath(), "start").Run()
+}
+
+func (s *tomatoSvc) Stop() error {
+	return exec.Command(s.configPath(), "stop").Run()
+}
+
+func (s *tomatoSvc) Restart() error {
+	return exec.Command(s.configPath(), "restart").Run()
+}
+
+// https://wiki.freshtomato.org/doku.php/freshtomato_zerotier?s[]=%2Aservice%2A
+const tomatoSvcScript = `#!/bin/sh
+ 
+
+NAME="{{.Name}}"
+CMD="{{.Path}}{{range .Arguments}} {{.}}{{end}}"
+LOG_FILE="/var/log/${NAME}.log"
+PID_FILE="/tmp/$NAME.pid"
+ 
+ 
+alias elog="logger -t $NAME -s"
+ 
+ 
+COND=$1
+[ $# -eq 0 ] && COND="start"
+ 
+get_pid() {
+  cat "$PID_FILE"
+}
+
+is_running() {
+  [ -f "$PID_FILE" ] && ps | grep -q "^ *$(get_pid) "
+}
+
+start() {
+  if is_running; then
+    elog "$NAME is already running."
+    exit 1
+  fi
+  elog "Starting $NAME Services: "
+  $CMD &
+  echo $! > "$PID_FILE"
+  chmod 600 "$PID_FILE"
+  if is_running; then
+    elog "succeeded."
+  else
+    elog "failed."
+  fi
+}
+ 
+ 
+stop() {
+  if ! is_running; then
+    elog "$NAME is not running."
+    exit 1
+  fi
+  elog "Shutting down $NAME Services: "
+  kill -SIGTERM "$(get_pid)"
+  for _ in 1 2 3 4 5; do
+    if ! is_running; then
+      if [ -f "$pid_file" ]; then
+        rm "$pid_file"
+      fi
+      exit 0
+    fi
+    printf "."
+    sleep 2
+  done
+  if ! is_running; then
+    elog "succeeded."
+  else
+    elog "failed."
+  fi
+}
+ 
+ 
+do_restart() {
+  stop
+  start
+}
+
+
+do_status() {
+  if ! is_running; then
+    echo "stopped"
+  else
+    echo "running"
+  fi
+}
+ 
+ 
+case "$COND" in
+start)
+  start
+  ;;
+stop)
+  stop
+  ;;
+restart)
+  do_restart
+  ;;
+status)
+  do_status
+  ;;
+*)
+  elog "Usage: $0 (start|stop|restart|status)"
+  ;;
+esac
+exit 0
+`

--- a/internal/router/service_tomato.go
+++ b/internal/router/service_tomato.go
@@ -229,7 +229,7 @@ stop() {
       if [ -f "$pid_file" ]; then
         rm "$pid_file"
       fi
-      exit 0
+      return 0
     fi
     printf "."
     sleep 2

--- a/internal/router/synology.go
+++ b/internal/router/synology.go
@@ -1,0 +1,55 @@
+package router
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const (
+	synologyDNSMasqConfigPath = "/etc/dhcpd/dhcpd-zzz-ctrld.conf"
+	synologyDhcpdInfoPath     = "/etc/dhcpd/dhcpd-zzz-ctrld.info"
+)
+
+func setupSynology() error {
+	dnsMasqConfigContent, err := dnsMasqConf()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(synologyDNSMasqConfigPath, []byte(dnsMasqConfigContent), 0600); err != nil {
+		return err
+	}
+	if err := os.WriteFile(synologyDhcpdInfoPath, []byte(`enable="yes"`), 0600); err != nil {
+		return err
+	}
+	if err := synologyRestartDNSMasq(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupSynology() error {
+	// Remove the custom config files.
+	for _, f := range []string{synologyDNSMasqConfigPath, synologyDhcpdInfoPath} {
+		if err := os.Remove(f); err != nil {
+			return err
+		}
+	}
+
+	// Restart dnsmasq service.
+	if err := synologyRestartDNSMasq(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func postInstallSynology() error {
+	return nil
+}
+
+func synologyRestartDNSMasq() error {
+	if out, err := exec.Command("/etc/rc.network", "nat-restart-dhcp").CombinedOutput(); err != nil {
+		return fmt.Errorf("synologyRestartDNSMasq: %s - %w", string(out), err)
+	}
+	return nil
+}

--- a/internal/router/synology.go
+++ b/internal/router/synology.go
@@ -22,7 +22,7 @@ func setupSynology() error {
 	if err := os.WriteFile(synologyDhcpdInfoPath, []byte(`enable="yes"`), 0600); err != nil {
 		return err
 	}
-	if err := synologyRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil
@@ -37,7 +37,7 @@ func cleanupSynology() error {
 	}
 
 	// Restart dnsmasq service.
-	if err := synologyRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil

--- a/internal/router/tomato.go
+++ b/internal/router/tomato.go
@@ -1,0 +1,108 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"tailscale.com/logtail/backoff"
+)
+
+const (
+	tomatoDnsCryptProxySvcName = "dnscrypt-proxy"
+	tomatoStubbySvcName        = "stubby"
+	tomatoDNSMasqSvcName       = "dnsmasq"
+)
+
+func setupTomato() error {
+	// Already setup.
+	if val, _ := nvram("get", nvramCtrldSetupKey); val == "1" {
+		return nil
+	}
+
+	data, err := dnsMasqConf()
+	if err != nil {
+		return err
+	}
+
+	nvramKvMap := nvramSetupKV()
+	nvramKvMap["dnsmasq_custom"] = data
+	if err := nvramSetKV(nvramKvMap, nvramCtrldSetupKey); err != nil {
+		return err
+	}
+
+	// Restart dnscrypt-proxy service.
+	if err := tomatoRestartServiceWithKill(tomatoDnsCryptProxySvcName, true); err != nil {
+		return err
+	}
+	// Restart stubby service.
+	if err := tomatoRestartService(tomatoStubbySvcName); err != nil {
+		return err
+	}
+	// Restart dnsmasq service.
+	if err := restartDNSMasq(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func postInstallTomato() error {
+	return nil
+}
+
+func cleanupTomato() error {
+	// Restore old configs.
+	if err := nvramRestore(nvramSetupKV(), nvramCtrldSetupKey); err != nil {
+		return err
+	}
+	// Restart dnscrypt-proxy service.
+	if err := tomatoRestartServiceWithKill(tomatoDnsCryptProxySvcName, true); err != nil {
+		return err
+	}
+	// Restart stubby service.
+	if err := tomatoRestartService(tomatoStubbySvcName); err != nil {
+		return err
+	}
+	// Restart dnsmasq service.
+	if err := restartDNSMasq(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func tomatoPreStart() (err error) {
+	// cleanup to trigger dnsmasq restart, so NTP can resolve
+	// server name and perform time synchronization.
+	if err = cleanupTomato(); err != nil {
+		return err
+	}
+
+	// Wait until `ntp_ready=1` set.
+	b := backoff.NewBackoff("PreStart", func(format string, args ...any) {}, 10*time.Second)
+	for {
+		out, err := nvram("get", "ntp_ready")
+		if err != nil {
+			return fmt.Errorf("PreStart: nvram: %w", err)
+		}
+		if out == "1" {
+			return nil
+		}
+		b.BackOff(context.Background(), errors.New("ntp not ready"))
+	}
+}
+
+func tomatoRestartService(name string) error {
+	return tomatoRestartServiceWithKill(name, false)
+}
+
+func tomatoRestartServiceWithKill(name string, killBeforeRestart bool) error {
+	if killBeforeRestart {
+		_, _ = exec.Command("killall", name).CombinedOutput()
+	}
+	if out, err := exec.Command("service", name, "restart").CombinedOutput(); err != nil {
+		return fmt.Errorf("service restart %s: %s, %w", name, string(out), err)
+	}
+	return nil
+}

--- a/internal/router/ubios.go
+++ b/internal/router/ubios.go
@@ -20,7 +20,7 @@ func setupUbiOS() error {
 		return err
 	}
 	// Restart dnsmasq service.
-	if err := ubiosRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil
@@ -32,7 +32,7 @@ func cleanupUbiOS() error {
 		return err
 	}
 	// Restart dnsmasq service.
-	if err := ubiosRestartDNSMasq(); err != nil {
+	if err := restartDNSMasq(); err != nil {
 		return err
 	}
 	return nil

--- a/internal/router/ubios.go
+++ b/internal/router/ubios.go
@@ -2,12 +2,17 @@ package router
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"strconv"
 )
 
+var errContentFilteringEnabled = fmt.Errorf(`the "Content Filtering" feature" is enabled, which is conflicted with ctrld.\n
+To disable it, folowing instruction here: %s`, toggleContentFilteringLink)
+
 const (
-	ubiosDNSMasqConfigPath = "/run/dnsmasq.conf.d/zzzctrld.conf"
+	ubiosDNSMasqConfigPath     = "/run/dnsmasq.conf.d/zzzctrld.conf"
+	toggleContentFilteringLink = "https://community.ui.com/questions/UDM-Pro-disable-enable-DNS-filtering/e2cc4060-e56a-4139-b200-62d7f773ff8f"
 )
 
 func setupUbiOS() error {
@@ -39,6 +44,10 @@ func cleanupUbiOS() error {
 }
 
 func postInstallUbiOS() error {
+	// See comment in postInstallEdgeOS.
+	if contentFilteringEnabled() {
+		return errContentFilteringEnabled
+	}
 	return nil
 }
 
@@ -56,4 +65,9 @@ func ubiosRestartDNSMasq() error {
 		return err
 	}
 	return proc.Kill()
+}
+
+func contentFilteringEnabled() bool {
+	st, err := os.Stat("/run/dnsfilter/dnsfilter")
+	return err == nil && !st.IsDir()
 }

--- a/net.go
+++ b/net.go
@@ -1,0 +1,46 @@
+package ctrld
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"tailscale.com/logtail/backoff"
+
+	ctrldnet "github.com/Control-D-Inc/ctrld/internal/net"
+)
+
+var (
+	hasIPv6Once   sync.Once
+	ipv6Available atomic.Bool
+)
+
+func hasIPv6() bool {
+	hasIPv6Once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		val := ctrldnet.IPv6Available(ctx)
+		ipv6Available.Store(val)
+		go probingIPv6(val)
+	})
+	return ipv6Available.Load()
+}
+
+// TODO(cuonglm): doing poll check natively for supported platforms.
+func probingIPv6(old bool) {
+	b := backoff.NewBackoff("probingIPv6", func(format string, args ...any) {}, 30*time.Second)
+	bCtx := context.Background()
+	for {
+		func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			cur := ctrldnet.IPv6Available(ctx)
+			if ipv6Available.CompareAndSwap(old, cur) {
+				old = cur
+			}
+		}()
+		b.BackOff(bCtx, errors.New("no change"))
+	}
+}

--- a/resolver.go
+++ b/resolver.go
@@ -125,7 +125,14 @@ func (r *legacyResolver) Resolve(ctx context.Context, msg *dns.Msg) (*dns.Msg, e
 		Net:    udpNet,
 		Dialer: dialer,
 	}
-	answer, _, err := dnsClient.ExchangeContext(ctx, msg, r.uc.Endpoint)
+	endpoint := r.uc.Endpoint
+	if r.uc.BootstrapIP != "" {
+		dnsClient.Net = "udp"
+		_, port, _ := net.SplitHostPort(endpoint)
+		endpoint = net.JoinHostPort(r.uc.BootstrapIP, port)
+	}
+
+	answer, _, err := dnsClient.ExchangeContext(ctx, msg, endpoint)
 	return answer, err
 }
 

--- a/resolver.go
+++ b/resolver.go
@@ -12,11 +12,17 @@ import (
 )
 
 const (
-	ResolverTypeDOH    = "doh"
-	ResolverTypeDOH3   = "doh3"
-	ResolverTypeDOT    = "dot"
-	ResolverTypeDOQ    = "doq"
-	ResolverTypeOS     = "os"
+	// ResolverTypeDOH specifies DoH resolver.
+	ResolverTypeDOH = "doh"
+	// ResolverTypeDOH3 specifies DoH3 resolver.
+	ResolverTypeDOH3 = "doh3"
+	// ResolverTypeDOT specifies DoT resolver.
+	ResolverTypeDOT = "dot"
+	// ResolverTypeDOQ specifies DoQ resolver.
+	ResolverTypeDOQ = "doq"
+	// ResolverTypeOS specifies OS resolver.
+	ResolverTypeOS = "os"
+	// ResolverTypeLegacy specifies legacy resolver.
 	ResolverTypeLegacy = "legacy"
 )
 

--- a/resolver.go
+++ b/resolver.go
@@ -201,3 +201,17 @@ func lookupIP(domain string, timeout int, withBootstrapDNS bool) (ips []string) 
 	}
 	return ips
 }
+
+// NewBootstrapResolver returns an OS resolver, which use following nameservers:
+//
+//   - ControlD bootstrap DNS server.
+//   - Gateway IP address (depends on OS).
+//   - Input servers.
+func NewBootstrapResolver(servers ...string) Resolver {
+	resolver := &osResolver{nameservers: nameservers()}
+	resolver.nameservers = append([]string{net.JoinHostPort(bootstrapDNS, "53")}, resolver.nameservers...)
+	for _, ns := range servers {
+		resolver.nameservers = append([]string{net.JoinHostPort(ns, "53")}, resolver.nameservers...)
+	}
+	return resolver
+}


### PR DESCRIPTION
_News_

- WSL support.
- Synology support.
- EdgeOS support.
- Pfsense support.
- Freshtomato support.

_Improvements_

- Reworking self-check mechanism to support ControlD .dev. resolver.
- Leverage DHCP lease file to spoof source IP on routers.
- On UDM, emitting error if "Content Filtering" is enabled, which will conflict with `ctrld`.
- Support old versions of Openwrt.

_Fixes_

- Fix split mode for all protocols but DoH.
- Fix wrong checking condition in pre-start causing `ctrld` failed to run on ddwrt.