### PR TITLE
Use 1.20-bullseye in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # - Non-cgo ctrld binary.
 #
 # CI_COMMIT_TAG is used to set the version of ctrld binary.
-FROM golang:bullseye as base
+FROM golang:1.20-bullseye as base
 
 WORKDIR /app
 


### PR DESCRIPTION
The current quic-go v0.32.0 could not be built with go 1.21, next release of ctrld will upgrade it to latest version.

Fixes #82