### PR TITLE
Change prefix on NetworkManager ctrld.conf to zz-

### DIFF
--- a/cmd/cli/network_manager_linux.go
+++ b/cmd/cli/network_manager_linux.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	nmConfDir           = "/etc/NetworkManager/conf.d"
-	nmCtrldConfFilename = "99-ctrld.conf"
+	nmCtrldConfFilename = "zz-ctrld.conf"
 	nmCtrldConfContent  = `[main]
 dns=none
 systemd-resolved=false


### PR DESCRIPTION
Updates the filename prefix of the NetworkManager config file from `99-ctrld.conf` to `zz-ctrld.conf`. This makes it so that the ctrld conf is applied after those not using numeric prefixes and should improve compatibility on NetworkManager installs.

In my case, ctrld was not working on my Steam Deck because the system includes a default `dns.conf` file, which was overriding the `99-ctrld.conf` file.