### PR TITLE
Release branch v1.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: "go test -race ./..."
-      - uses: dominikh/staticcheck-action@v1.2.0
+      - uses: dominikh/staticcheck-action@v1.3.1
         with:
           version: "2024.1.1"
           install-go: false

--- a/cmd/cli/cgo.go
+++ b/cmd/cli/cgo.go
@@ -1,0 +1,5 @@
+//go:build cgo
+
+package cli
+
+const cgoEnabled = true

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -61,7 +61,7 @@ var (
 	v                    = viper.NewWithOptions(viper.KeyDelimiter("::"))
 	defaultConfigFile    = "ctrld.toml"
 	rootCertPool         *x509.CertPool
-	errSelfCheckNoAnswer = errors.New("No response from ctrld listener. You can try to re-launch with flag --skip_self_checks")
+	errSelfCheckNoAnswer = errors.New("no response from ctrld listener. You can try to re-launch with flag --skip_self_checks")
 )
 
 var basicModeFlags = []string{"listen", "primary_upstream", "secondary_upstream", "domains"}

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -222,10 +222,16 @@ func run(appCallback *AppCallback, stopCh chan struct{}) {
 			lc := &logConn{conn: conn}
 			consoleWriter.Out = io.MultiWriter(os.Stdout, lc)
 			p.logConn = lc
+		} else {
+			mainLog.Load().Warn().Err(err).Msgf("unable to create log ipc connection")
 		}
+	} else {
+		mainLog.Load().Warn().Err(err).Msgf("unable to resolve socket address: %s", sockPath)
 	}
 	notifyExitToLogServer := func() {
-		_, _ = p.logConn.Write([]byte(msgExit))
+		if p.logConn != nil {
+			_, _ = p.logConn.Write([]byte(msgExit))
+		}
 	}
 
 	if daemon && runtime.GOOS == "windows" {

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -860,7 +860,7 @@ func selfCheckStatus(ctx context.Context, s service.Service, sockDir string) (bo
 func selfCheckResolveDomain(ctx context.Context, addr, scope string, domain string) error {
 	bo := backoff.NewBackoff("self-check", logf, 10*time.Second)
 	bo.LogLongerThan = 500 * time.Millisecond
-	maxAttempts := 20
+	maxAttempts := 10
 	c := new(dns.Client)
 
 	var (
@@ -876,7 +876,7 @@ func selfCheckResolveDomain(ctx context.Context, addr, scope string, domain stri
 		m := new(dns.Msg)
 		m.SetQuestion(domain+".", dns.TypeA)
 		m.RecursionDesired = true
-		r, _, exErr := exchangeContextWithTimeout(c, time.Second, m, addr)
+		r, _, exErr := exchangeContextWithTimeout(c, 5*time.Second, m, addr)
 		if r != nil && r.Rcode == dns.RcodeSuccess && len(r.Answer) > 0 {
 			mainLog.Load().Debug().Msgf("%s self-check against %q succeeded", scope, domain)
 			return nil

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -61,7 +61,7 @@ var (
 	v                    = viper.NewWithOptions(viper.KeyDelimiter("::"))
 	defaultConfigFile    = "ctrld.toml"
 	rootCertPool         *x509.CertPool
-	errSelfCheckNoAnswer = errors.New("no answer from ctrld listener")
+	errSelfCheckNoAnswer = errors.New("No response from ctrld listener. You can try to re-launch with flag --skip_self_checks")
 )
 
 var basicModeFlags = []string{"listen", "primary_upstream", "secondary_upstream", "domains"}

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -853,10 +853,12 @@ func selfCheckStatus(ctx context.Context, s service.Service, sockDir string) (bo
 	}
 
 	mainLog.Load().Debug().Msg("ctrld listener is ready")
-	mainLog.Load().Debug().Msg("performing self-check")
 
 	lc := cfg.FirstListener()
 	addr := net.JoinHostPort(lc.IP, strconv.Itoa(lc.Port))
+
+	mainLog.Load().Debug().Msgf("performing listener test, sending queries to %s", addr)
+
 	if err := selfCheckResolveDomain(context.TODO(), addr, "internal", selfCheckInternalTestDomain); err != nil {
 		return false, status, err
 	}

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1839,6 +1839,12 @@ func doValidateCdRemoteConfig(cdUID string, fatal bool) error {
 			return err
 		}
 	}
+
+	// return earlier if there's no custom config.
+	if rc.Ctrld.CustomConfig == "" {
+		return nil
+	}
+
 	// validateCdRemoteConfig clobbers v, saving it here to restore later.
 	oldV := v
 	var cfgErr error

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1866,6 +1866,9 @@ func doValidateCdRemoteConfig(cdUID string, fatal bool) error {
 		} else {
 			mainLog.Load().Error().Msgf("failed to unmarshal custom config: %v", err)
 		}
+	} else {
+		setListenerDefaultValue(remoteCfg)
+		setNetworkDefaultValue(remoteCfg)
 	}
 	cfgErr = validateConfig(remoteCfg)
 	if cfgErr != nil {

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -781,7 +781,13 @@ func defaultIfaceName() string {
 		if oi := osinfo.New(); strings.Contains(oi.String(), "Microsoft") {
 			return "lo"
 		}
-		mainLog.Load().Fatal().Err(err).Msg("failed to get default route interface")
+		// On linux, it could be either resolvconf or systemd which is managing DNS settings,
+		// so the interface name does not matter if there's no default route interface.
+		if runtime.GOOS == "linux" {
+			return "lo"
+		}
+		mainLog.Load().Debug().Err(err).Msg("no default route interface found")
+		return ""
 	}
 	return dri
 }

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -266,10 +266,7 @@ func run(appCallback *AppCallback, stopCh chan struct{}) {
 
 	// Log config do not have thing to validate, so it's safe to init log here,
 	// so it's able to log information in processCDFlags.
-	logWriters := initLogging()
-
-	// Initializing internal logging after global logging.
-	p.initInternalLogging(logWriters)
+	p.initLogging(true)
 
 	mainLog.Load().Info().Msgf("starting ctrld %s", curVersion())
 	mainLog.Load().Info().Msgf("os: %s", osVersion())

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1739,8 +1739,13 @@ func goArm() string {
 // upgradeUrl returns the url for downloading new ctrld binary.
 func upgradeUrl(baseUrl string) string {
 	dlPath := fmt.Sprintf("%s-%s/ctrld", runtime.GOOS, runtime.GOARCH)
+	// Use arm version set during build time, v5 binary can be run on higher arm version system.
 	if armVersion := goArm(); armVersion != "" {
 		dlPath = fmt.Sprintf("%s-%sv%s/ctrld", runtime.GOOS, runtime.GOARCH, armVersion)
+	}
+	// linux/amd64 has nocgo version, to support systems that missing some libc (like openwrt).
+	if !cgoEnabled && runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
+		dlPath = fmt.Sprintf("%s-%s-nocgo/ctrld", runtime.GOOS, runtime.GOARCH)
 	}
 	dlUrl := fmt.Sprintf("%s/%s", baseUrl, dlPath)
 	if runtime.GOOS == "windows" {

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1843,7 +1843,11 @@ func doValidateCdRemoteConfig(cdUID string, fatal bool) error {
 	oldV := v
 	var cfgErr error
 	remoteCfg := &ctrld.Config{}
-	if cfgErr = validateCdRemoteConfig(rc, remoteCfg); cfgErr != nil {
+	if cfgErr = validateCdRemoteConfig(rc, remoteCfg); cfgErr == nil {
+		setListenerDefaultValue(remoteCfg)
+		setNetworkDefaultValue(remoteCfg)
+		cfgErr = validateConfig(remoteCfg)
+	} else {
 		if errors.As(cfgErr, &viper.ConfigParseError{}) {
 			if configStr, _ := base64.StdEncoding.DecodeString(rc.Ctrld.CustomConfig); len(configStr) > 0 {
 				tmpDir := os.TempDir()
@@ -1866,11 +1870,7 @@ func doValidateCdRemoteConfig(cdUID string, fatal bool) error {
 		} else {
 			mainLog.Load().Error().Msgf("failed to unmarshal custom config: %v", err)
 		}
-	} else {
-		setListenerDefaultValue(remoteCfg)
-		setNetworkDefaultValue(remoteCfg)
 	}
-	cfgErr = validateConfig(remoteCfg)
 	if cfgErr != nil {
 		mainLog.Load().Warn().Msg("disregarding invalid custom config")
 	}

--- a/cmd/cli/commands.go
+++ b/cmd/cli/commands.go
@@ -205,7 +205,13 @@ func initStartCmd() *cobra.Command {
 		Long: `Install and start the ctrld service
 
 NOTE: running "ctrld start" without any arguments will start already installed ctrld service.`,
-		Args: cobra.NoArgs,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("'ctrld start' doesn't accept positional arguments\n" +
+					"Use flags instead (e.g. --cd, --iface) or see 'ctrld start --help' for all options")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			checkStrFlagEmpty(cmd, cdUidFlagName)
 			checkStrFlagEmpty(cmd, cdOrgFlagName)
@@ -555,6 +561,13 @@ NOTE: running "ctrld start" without any arguments will start already installed c
 		Long: `Quick start service and configure DNS on interface
 
 NOTE: running "ctrld start" without any arguments will start already installed ctrld service.`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("'ctrld start' doesn't accept positional arguments\n" +
+					"Use flags instead (e.g. --cd, --iface) or see 'ctrld start --help' for all options")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(os.Args) == 2 {
 				startOnly = true

--- a/cmd/cli/commands.go
+++ b/cmd/cli/commands.go
@@ -248,7 +248,7 @@ NOTE: running "ctrld start" without any arguments will start already installed c
 					os.Exit(deactivationPinInvalidExitCode)
 				}
 				currentIface = runningIface(s)
-				mainLog.Load().Debug().Msgf("current interface on start: %s", currentIface.Name)
+				mainLog.Load().Debug().Msgf("current interface on start: %v", currentIface)
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/cli/commands.go
+++ b/cmd/cli/commands.go
@@ -462,6 +462,9 @@ NOTE: running "ctrld start" without any arguments will start already installed c
 					return
 				}
 
+				// add a small delay to ensure the service is started and did not crash
+				time.Sleep(1 * time.Second)
+
 				ok, status, err := selfCheckStatus(ctx, s, sockDir)
 				switch {
 				case ok && status == service.StatusRunning:

--- a/cmd/cli/commands.go
+++ b/cmd/cli/commands.go
@@ -1273,7 +1273,8 @@ func initUpgradeCmd() *cobra.Command {
 			}
 			dlUrl := upgradeUrl(baseUrl)
 			mainLog.Load().Debug().Msgf("Downloading binary: %s", dlUrl)
-			resp, err := http.Get(dlUrl)
+
+			resp, err := getWithRetry(dlUrl)
 			if err != nil {
 				mainLog.Load().Fatal().Err(err).Msg("failed to download binary")
 			}

--- a/cmd/cli/control_server.go
+++ b/cmd/cli/control_server.go
@@ -250,7 +250,7 @@ func (p *prog) registerControlServerHandler() {
 		}
 	}))
 	p.cs.register(sendLogsPath, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		if time.Since(p.internalLogSent) < logSentInterval {
+		if time.Since(p.internalLogSent) < logWriterSentInterval {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}

--- a/cmd/cli/dns_proxy.go
+++ b/cmd/cli/dns_proxy.go
@@ -640,19 +640,20 @@ func (p *prog) proxy(ctx context.Context, req *proxyRequest) *proxyResponse {
 		} else {
 			mainLog.Load().Debug().Msg("One upstream is down but at least one is healthy; skipping recovery trigger")
 		}
-	}
 
-	// attempt query to OS resolver while as a retry catch all
-	if upstreams[0] != upstreamOS {
-		ctrld.Log(ctx, mainLog.Load().Debug(), "attempting query to OS resolver as a retry catch all")
-		answer := resolve(upstreamOS, osUpstreamConfig, req.msg)
-		if answer != nil {
-			ctrld.Log(ctx, mainLog.Load().Debug(), "OS resolver retry query successful")
-			res.answer = answer
-			res.upstream = osUpstreamConfig.Endpoint
-			return res
+		// attempt query to OS resolver while as a retry catch all
+		// we dont want this to happen if leakOnUpstreamFailure is false
+		if upstreams[0] != upstreamOS {
+			ctrld.Log(ctx, mainLog.Load().Debug(), "attempting query to OS resolver as a retry catch all")
+			answer := resolve(upstreamOS, osUpstreamConfig, req.msg)
+			if answer != nil {
+				ctrld.Log(ctx, mainLog.Load().Debug(), "OS resolver retry query successful")
+				res.answer = answer
+				res.upstream = osUpstreamConfig.Endpoint
+				return res
+			}
+			ctrld.Log(ctx, mainLog.Load().Debug(), "OS resolver retry query failed")
 		}
-		ctrld.Log(ctx, mainLog.Load().Debug(), "OS resolver retry query failed")
 	}
 
 	answer := new(dns.Msg)

--- a/cmd/cli/dns_proxy_test.go
+++ b/cmd/cli/dns_proxy_test.go
@@ -418,20 +418,21 @@ func Test_isPrivatePtrLookup(t *testing.T) {
 	}
 }
 
-func Test_isSrvLookup(t *testing.T) {
+func Test_isSrvLanLookup(t *testing.T) {
 	tests := []struct {
 		name        string
 		msg         *dns.Msg
 		isSrvLookup bool
 	}{
-		{"SRV", newDnsMsgWithHostname("foo", dns.TypeSRV), true},
+		{"SRV LAN", newDnsMsgWithHostname("foo", dns.TypeSRV), true},
 		{"Not SRV", newDnsMsgWithHostname("foo", dns.TypeNone), false},
+		{"Not SRV LAN", newDnsMsgWithHostname("controld.com", dns.TypeSRV), false},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := isSrvLookup(tc.msg); tc.isSrvLookup != got {
+			if got := isSrvLanLookup(tc.msg); tc.isSrvLookup != got {
 				t.Errorf("unexpected result, want: %v, got: %v", tc.isSrvLookup, got)
 			}
 		})

--- a/cmd/cli/library.go
+++ b/cmd/cli/library.go
@@ -1,5 +1,12 @@
 package cli
 
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
 // AppCallback provides hooks for injecting certain functionalities
 // from mobile platforms to main ctrld cli.
 type AppCallback struct {
@@ -16,4 +23,56 @@ type AppConfig struct {
 	UpstreamProto string
 	Verbose       int
 	LogPath       string
+}
+
+const (
+	defaultHTTPTimeout = 30 * time.Second
+	defaultMaxRetries  = 3
+)
+
+// httpClientWithFallback returns an HTTP client configured with timeout and IPv4 fallback
+func httpClientWithFallback(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// Prefer IPv4 over IPv6
+			DialContext: (&net.Dialer{
+				Timeout:       10 * time.Second,
+				KeepAlive:     30 * time.Second,
+				FallbackDelay: 1 * time.Millisecond, // Very small delay to prefer IPv4
+			}).DialContext,
+		},
+	}
+}
+
+// doWithRetry performs an HTTP request with retries
+func doWithRetry(req *http.Request, maxRetries int) (*http.Response, error) {
+	var lastErr error
+	client := httpClientWithFallback(defaultHTTPTimeout)
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Second * time.Duration(attempt+1)) // Exponential backoff
+		}
+
+		resp, err := client.Do(req)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		mainLog.Load().Debug().Err(err).
+			Str("method", req.Method).
+			Str("url", req.URL.String()).
+			Msgf("HTTP request attempt %d/%d failed", attempt+1, maxRetries)
+	}
+	return nil, fmt.Errorf("failed after %d attempts to %s %s: %v", maxRetries, req.Method, req.URL, lastErr)
+}
+
+// Helper for making GET requests with retries
+func getWithRetry(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return doWithRetry(req, defaultMaxRetries)
 }

--- a/cmd/cli/log_writer.go
+++ b/cmd/cli/log_writer.go
@@ -93,6 +93,15 @@ func (lw *logWriter) Write(p []byte) (int, error) {
 	return lw.buf.Write(p)
 }
 
+// initLogging initializes global logging setup.
+func (p *prog) initLogging(backup bool) {
+	zerolog.TimeFieldFormat = time.RFC3339 + ".000"
+	logWriters := initLoggingWithBackup(backup)
+
+	// Initializing internal logging after global logging.
+	p.initInternalLogging(logWriters)
+}
+
 // initInternalLogging performs internal logging if there's no log enabled.
 func (p *prog) initInternalLogging(writers []io.Writer) {
 	if !p.needInternalLogging() {

--- a/cmd/cli/log_writer.go
+++ b/cmd/cli/log_writer.go
@@ -16,13 +16,12 @@ import (
 )
 
 const (
-	logWriterSize        = 1024 * 1024 * 5 // 5 MB
-	logWriterSmallSize   = 1024 * 1024 * 1 // 1 MB
-	logWriterInitialSize = 32 * 1024       // 32 KB
-	logSentInterval      = time.Minute
-	logStartEndMarker    = "\n\n=== INIT_END ===\n\n"
-	logLogEndMarker      = "\n\n=== LOG_END ===\n\n"
-	logWarnEndMarker     = "\n\n=== WARN_END ===\n\n"
+	logWriterSize          = 1024 * 1024 * 5 // 5 MB
+	logWriterSmallSize     = 1024 * 1024 * 1 // 1 MB
+	logWriterInitialSize   = 32 * 1024       // 32 KB
+	logWriterSentInterval  = time.Minute
+	logWriterInitEndMarker = "\n\n=== INIT_END ===\n\n"
+	logWriterLogEndMarker  = "\n\n=== LOG_END ===\n\n"
 )
 
 type logViewResponse struct {
@@ -69,13 +68,23 @@ func (lw *logWriter) Write(p []byte) (int, error) {
 	// If writing p causes overflows, discard old data.
 	if lw.buf.Len()+len(p) > lw.size {
 		buf := lw.buf.Bytes()
-		buf = buf[:logWriterInitialSize]
-		if idx := bytes.LastIndex(buf, []byte("\n")); idx != -1 {
-			buf = buf[:idx]
+		haveEndMarker := false
+		// If there's init end marker already, preserve the data til the marker.
+		if idx := bytes.LastIndex(buf, []byte(logWriterInitEndMarker)); idx >= 0 {
+			buf = buf[:idx+len(logWriterInitEndMarker)]
+			haveEndMarker = true
+		} else {
+			// Otherwise, preserve the initial size data.
+			buf = buf[:logWriterInitialSize]
+			if idx := bytes.LastIndex(buf, []byte("\n")); idx != -1 {
+				buf = buf[:idx]
+			}
 		}
 		lw.buf.Reset()
 		lw.buf.Write(buf)
-		lw.buf.WriteString(logStartEndMarker) // indicate that the log was truncated.
+		if !haveEndMarker {
+			lw.buf.WriteString(logWriterInitEndMarker) // indicate that the log was truncated.
+		}
 	}
 	// If p is bigger than buffer size, truncate p by half until its size is smaller.
 	for len(p)+lw.buf.Len() > lw.size {
@@ -92,7 +101,7 @@ func (p *prog) initInternalLogging(writers []io.Writer) {
 	p.initInternalLogWriterOnce.Do(func() {
 		mainLog.Load().Notice().Msg("internal logging enabled")
 		p.internalLogWriter = newLogWriter()
-		p.internalLogSent = time.Now().Add(-logSentInterval)
+		p.internalLogSent = time.Now().Add(-logWriterSentInterval)
 		p.internalWarnLogWriter = newSmallLogWriter()
 	})
 	p.mu.Lock()
@@ -158,7 +167,7 @@ func (p *prog) logReader() (*logReader, error) {
 		wlwReader := bytes.NewReader(wlw.buf.Bytes())
 		wlwSize := wlw.buf.Len()
 		wlw.mu.Unlock()
-		reader := io.MultiReader(lwReader, bytes.NewReader([]byte(logLogEndMarker)), wlwReader)
+		reader := io.MultiReader(lwReader, bytes.NewReader([]byte(logWriterLogEndMarker)), wlwReader)
 		lr := &logReader{r: io.NopCloser(reader)}
 		lr.size = int64(lwSize + wlwSize)
 		if lr.size == 0 {

--- a/cmd/cli/log_writer_test.go
+++ b/cmd/cli/log_writer_test.go
@@ -16,7 +16,7 @@ func Test_logWriter_Write(t *testing.T) {
 		t.Fatalf("unexpected buf content: %v", lw.buf.String())
 	}
 	newData := "B"
-	halfData := strings.Repeat("A", len(data)/2) + logStartEndMarker
+	halfData := strings.Repeat("A", len(data)/2) + logWriterInitEndMarker
 	lw.Write([]byte(newData))
 	if lw.buf.String() != halfData+newData {
 		t.Fatalf("unexpected new buf content: %v", lw.buf.String())
@@ -45,5 +45,41 @@ func Test_logWriter_ConcurrentWrite(t *testing.T) {
 	wg.Wait()
 	if lw.buf.Len() > lw.size {
 		t.Fatalf("unexpected buf size: %v, content: %q", lw.buf.Len(), lw.buf.String())
+	}
+}
+
+func Test_logWriter_MarkerInitEnd(t *testing.T) {
+	size := 64 * 1024
+	lw := &logWriter{size: size}
+	lw.buf.Grow(lw.size)
+
+	paddingSize := 10
+	// Writing half of the size, minus len(end marker) and padding size.
+	dataSize := size/2 - len(logWriterInitEndMarker) - paddingSize
+	data := strings.Repeat("A", dataSize)
+	// Inserting newline for making partial init data
+	data += "\n"
+	// Filling left over buffer to make the log full.
+	// The data length: len(end marker) + padding size - 1 (for newline above) + size/2
+	data += strings.Repeat("A", len(logWriterInitEndMarker)+paddingSize-1+(size/2))
+	lw.Write([]byte(data))
+	if lw.buf.String() != data {
+		t.Fatalf("unexpected buf content: %v", lw.buf.String())
+	}
+	lw.Write([]byte("B"))
+	lw.Write([]byte(strings.Repeat("B", 256*1024)))
+	firstIdx := strings.Index(lw.buf.String(), logWriterInitEndMarker)
+	lastIdx := strings.LastIndex(lw.buf.String(), logWriterInitEndMarker)
+	// Check if init end marker present.
+	if firstIdx == -1 || lastIdx == -1 {
+		t.Fatalf("missing init end marker: %s", lw.buf.String())
+	}
+	// Check if init end marker appears only once.
+	if firstIdx != lastIdx {
+		t.Fatalf("log init end marker appears more than once: %s", lw.buf.String())
+	}
+	// Ensure that we have the correct init log data.
+	if !strings.Contains(lw.buf.String(), strings.Repeat("A", dataSize)+logWriterInitEndMarker) {
+		t.Fatalf("unexpected log content: %s", lw.buf.String())
 	}
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -103,12 +103,6 @@ func initConsoleLogging() {
 	}
 }
 
-// initLogging initializes global logging setup.
-func initLogging() []io.Writer {
-	zerolog.TimeFieldFormat = time.RFC3339 + ".000"
-	return initLoggingWithBackup(true)
-}
-
 // initInteractiveLogging is like initLogging, but the ProxyLogger is discarded
 // to be used for all interactive commands.
 //

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -88,12 +88,15 @@ func initConsoleLogging() {
 	multi := zerolog.MultiLevelWriter(consoleWriter)
 	l := mainLog.Load().Output(multi).With().Timestamp().Logger()
 	mainLog.Store(&l)
+
 	switch {
 	case silent:
 		zerolog.SetGlobalLevel(zerolog.NoLevel)
 	case verbose == 1:
+		ctrld.ProxyLogger.Store(&l)
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	case verbose > 1:
+		ctrld.ProxyLogger.Store(&l)
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	default:
 		zerolog.SetGlobalLevel(zerolog.NoticeLevel)

--- a/cmd/cli/nocgo.go
+++ b/cmd/cli/nocgo.go
@@ -1,0 +1,5 @@
+//go:build !cgo
+
+package cli
+
+const cgoEnabled = false

--- a/cmd/cli/os_linux.go
+++ b/cmd/cli/os_linux.go
@@ -160,6 +160,7 @@ func resetDNS(iface *net.Interface) (err error) {
 	}
 
 	// TODO(cuonglm): handle DHCPv6 properly.
+	mainLog.Load().Debug().Msg("checking for IPv6 availability")
 	if ctrldnet.IPv6Available(ctx) {
 		c := client6.NewClient()
 		conversation, err := c.Exchange(iface.Name)
@@ -179,6 +180,8 @@ func resetDNS(iface *net.Interface) (err error) {
 				}
 			}
 		}
+	} else {
+		mainLog.Load().Debug().Msg("IPv6 is not available")
 	}
 
 	return ignoringEINTR(func() error {

--- a/cmd/cli/os_linux.go
+++ b/cmd/cli/os_linux.go
@@ -110,8 +110,8 @@ systemdResolve:
 			}
 			time.Sleep(time.Second)
 		}
+		mainLog.Load().Debug().Msg("DNS was not set for some reason")
 	}
-	mainLog.Load().Debug().Msg("DNS was not set for some reason")
 	return nil
 }
 

--- a/cmd/cli/os_windows.go
+++ b/cmd/cli/os_windows.go
@@ -147,15 +147,32 @@ func restoreDNS(iface *net.Interface) (err error) {
 			}
 		}
 
-		for _, ns := range [][]string{v4ns, v6ns} {
-			if len(ns) == 0 {
-				continue
-			}
-			mainLog.Load().Debug().Msgf("setting static DNS for interface %q", iface.Name)
-			err = setDNS(iface, ns)
+		luid, err := winipcfg.LUIDFromIndex(uint32(iface.Index))
+		if err != nil {
+			return fmt.Errorf("restoreDNS: %w", err)
+		}
 
-			if err != nil {
-				return err
+		if len(v4ns) > 0 {
+			mainLog.Load().Debug().Msgf("restoring IPv4 static DNS for interface %q: %v", iface.Name, v4ns)
+			if err := setDNS(iface, v4ns); err != nil {
+				return fmt.Errorf("restoreDNS (IPv4): %w", err)
+			}
+		} else {
+			mainLog.Load().Debug().Msgf("restoring IPv4 DHCP for interface %q", iface.Name)
+			if err := luid.SetDNS(windows.AF_INET, nil, nil); err != nil {
+				return fmt.Errorf("restoreDNS (IPv4 clear): %w", err)
+			}
+		}
+
+		if len(v6ns) > 0 {
+			mainLog.Load().Debug().Msgf("restoring IPv6 static DNS for interface %q: %v", iface.Name, v6ns)
+			if err := setDNS(iface, v6ns); err != nil {
+				return fmt.Errorf("restoreDNS (IPv6): %w", err)
+			}
+		} else {
+			mainLog.Load().Debug().Msgf("restoring IPv6 DHCP for interface %q", iface.Name)
+			if err := luid.SetDNS(windows.AF_INET6, nil, nil); err != nil {
+				return fmt.Errorf("restoreDNS (IPv6 clear): %w", err)
 			}
 		}
 	}
@@ -180,41 +197,63 @@ func currentDNS(iface *net.Interface) []string {
 	return ns
 }
 
-// currentStaticDNS returns the current static DNS settings of given interface.
+// currentStaticDNS checks both the IPv4 and IPv6 paths for static DNS values using keys
+// like "NameServer" and "ProfileNameServer".
 func currentStaticDNS(iface *net.Interface) ([]string, error) {
 	luid, err := winipcfg.LUIDFromIndex(uint32(iface.Index))
 	if err != nil {
-		return nil, fmt.Errorf("winipcfg.LUIDFromIndex: %w", err)
+		return nil, fmt.Errorf("fallback winipcfg.LUIDFromIndex: %w", err)
 	}
 	guid, err := luid.GUID()
 	if err != nil {
-		return nil, fmt.Errorf("luid.GUID: %w", err)
+		return nil, fmt.Errorf("fallback luid.GUID: %w", err)
 	}
+
 	var ns []string
-	for _, path := range []string{v4InterfaceKeyPathFormat, v6InterfaceKeyPathFormat} {
-		found := false
+	keyPaths := []string{v4InterfaceKeyPathFormat, v6InterfaceKeyPathFormat}
+	for _, path := range keyPaths {
 		interfaceKeyPath := path + guid.String()
 		k, err := registry.OpenKey(registry.LOCAL_MACHINE, interfaceKeyPath, registry.QUERY_VALUE)
 		if err != nil {
-			return nil, fmt.Errorf("%s: %w", interfaceKeyPath, err)
+			mainLog.Load().Debug().Err(err).Msgf("failed to open registry key %q for interface %q; trying next key", interfaceKeyPath, iface.Name)
+			continue
 		}
-		for _, key := range []string{"NameServer", "ProfileNameServer"} {
-			if found {
-				continue
-			}
-			value, _, err := k.GetStringValue(key)
-			if err != nil && !errors.Is(err, registry.ErrNotExist) {
-				return nil, fmt.Errorf("%s: %w", key, err)
-			}
-			if len(value) > 0 {
-				found = true
-				for _, e := range strings.Split(value, ",") {
-					ns = append(ns, strings.TrimRight(e, "\x00"))
+		func() {
+			defer k.Close()
+			for _, keyName := range []string{"NameServer", "ProfileNameServer"} {
+				value, _, err := k.GetStringValue(keyName)
+				if err != nil && !errors.Is(err, registry.ErrNotExist) {
+					mainLog.Load().Debug().Err(err).Msgf("error reading %s registry key", keyName)
+					continue
+				}
+				if len(value) > 0 {
+					mainLog.Load().Debug().Msgf("found static DNS for interface %q: %s", iface.Name, value)
+					parsed := parseDNSServers(value)
+					ns = append(ns, parsed...)
 				}
 			}
-		}
+		}()
+	}
+	if len(ns) == 0 {
+		mainLog.Load().Debug().Msgf("no static DNS values found for interface %q", iface.Name)
 	}
 	return ns, nil
+}
+
+// parseDNSServers splits a DNS server string that may be comma- or space-separated,
+// and trims any extraneous whitespace or null characters.
+func parseDNSServers(val string) []string {
+	fields := strings.FieldsFunc(val, func(r rune) bool {
+		return r == ' ' || r == ','
+	})
+	var servers []string
+	for _, f := range fields {
+		trimmed := strings.TrimSpace(f)
+		if len(trimmed) > 0 {
+			servers = append(servers, trimmed)
+		}
+	}
+	return servers
 }
 
 // addDnsServerForwarders adds given nameservers to DNS server forwarders list,

--- a/cmd/cli/prog.go
+++ b/cmd/cli/prog.go
@@ -1314,6 +1314,10 @@ var errSaveCurrentStaticDNSNotSupported = errors.New("saving current DNS is not 
 // saveCurrentStaticDNS saves the current static DNS settings for restoring later.
 // Only works on Windows and Mac.
 func saveCurrentStaticDNS(iface *net.Interface) error {
+	if iface == nil {
+		mainLog.Load().Debug().Msg("could not save current static DNS settings for nil interface")
+		return nil
+	}
 	switch runtime.GOOS {
 	case "windows", "darwin":
 	default:
@@ -1355,6 +1359,9 @@ func saveCurrentStaticDNS(iface *net.Interface) error {
 
 // savedStaticDnsSettingsFilePath returns the path to saved DNS settings of the given interface.
 func savedStaticDnsSettingsFilePath(iface *net.Interface) string {
+	if iface == nil {
+		return ""
+	}
 	return absHomeDir(".dns_" + iface.Name)
 }
 
@@ -1362,6 +1369,10 @@ func savedStaticDnsSettingsFilePath(iface *net.Interface) string {
 //
 //lint:ignore U1000 use in os_windows.go and os_darwin.go
 func savedStaticNameservers(iface *net.Interface) []string {
+	if iface == nil {
+		mainLog.Load().Debug().Msg("could not get saved static DNS settings for nil interface")
+		return nil
+	}
 	file := savedStaticDnsSettingsFilePath(iface)
 	if data, _ := os.ReadFile(file); len(data) > 0 {
 		saveValues := strings.Split(string(data), ",")

--- a/cmd/cli/prog.go
+++ b/cmd/cli/prog.go
@@ -43,7 +43,7 @@ const (
 	ctrldControlUnixSockMobile = "cd.sock"
 	upstreamPrefix             = "upstream."
 	upstreamOS                 = upstreamPrefix + "os"
-	upstreamPrivate            = upstreamPrefix + "private"
+	upstreamOSLocal            = upstreamOS + ".local"
 	dnsWatchdogDefaultInterval = 20 * time.Second
 	ctrldServiceName           = "ctrld"
 )

--- a/cmd/cli/prog.go
+++ b/cmd/cli/prog.go
@@ -560,13 +560,12 @@ func (p *prog) run(reload bool, reloadCh chan struct{}) {
 	if !reload {
 		// Stop writing log to unix socket.
 		consoleWriter.Out = os.Stdout
-		logWriters := initLoggingWithBackup(false)
+		p.initLogging(false)
 		if p.logConn != nil {
 			_ = p.logConn.Close()
 		}
 		go p.apiConfigReload()
 		p.postRun()
-		p.initInternalLogging(logWriters)
 	}
 	wg.Wait()
 }

--- a/cmd/cli/prog.go
+++ b/cmd/cli/prog.go
@@ -985,12 +985,6 @@ func findWorkingInterface(currentIface string) string {
 	return currentIface
 }
 
-// recoverOnUpstreamFailure reports whether ctrld should recover from upstream failure.
-func (p *prog) recoverOnUpstreamFailure() bool {
-	// Default is false on routers, since this recovery flow is only useful for devices that move between networks.
-	return router.Name() == ""
-}
-
 func randomLocalIP() string {
 	n := rand.Intn(254-2) + 2
 	return fmt.Sprintf("127.0.0.%d", n)
@@ -1285,4 +1279,17 @@ func selfUninstallCheck(uninstallErr error, p *prog, logger zerolog.Logger) {
 		// Perform self-uninstall now.
 		selfUninstall(p, logger)
 	}
+}
+
+// leakOnUpstreamFailure reports whether ctrld should initiate a recovery flow
+// when upstream failures occur.
+func (p *prog) leakOnUpstreamFailure() bool {
+	if ptr := p.cfg.Service.LeakOnUpstreamFailure; ptr != nil {
+		return *ptr
+	}
+	// Default is false on routers, since this leaking is only useful for devices that move between networks.
+	if router.Name() != "" {
+		return false
+	}
+	return true
 }

--- a/cmd/cli/prog.go
+++ b/cmd/cli/prog.go
@@ -359,6 +359,7 @@ func (p *prog) apiConfigReload() {
 				return
 			}
 			setListenerDefaultValue(cfg)
+			setNetworkDefaultValue(cfg)
 			logger.Debug().Msg("custom config changes detected, reloading...")
 			p.apiReloadCh <- cfg
 		} else {

--- a/cmd/cli/prog_linux.go
+++ b/cmd/cli/prog_linux.go
@@ -13,6 +13,7 @@ import (
 	"tailscale.com/health"
 
 	"github.com/Control-D-Inc/ctrld/internal/dns"
+	"github.com/Control-D-Inc/ctrld/internal/router"
 )
 
 func init() {
@@ -38,6 +39,9 @@ func setDependencies(svc *service.Config) {
 		if wantsSystemDNetworkdWaitOnline(bytes.NewReader(out)) {
 			svc.Dependencies = append(svc.Dependencies, "Wants=systemd-networkd-wait-online.service")
 		}
+	}
+	if routerDeps := router.ServiceDependencies(); len(routerDeps) > 0 {
+		svc.Dependencies = append(svc.Dependencies, routerDeps...)
 	}
 }
 

--- a/cmd/cli/prog_windows.go
+++ b/cmd/cli/prog_windows.go
@@ -1,10 +1,12 @@
-//go:build !linux && !freebsd && !darwin && !windows
-
 package cli
 
 import "github.com/kardianos/service"
 
-func setDependencies(svc *service.Config) {}
+func setDependencies(svc *service.Config) {
+	if hasLocalDnsServerRunning() {
+		svc.Dependencies = []string{"DNS"}
+	}
+}
 
 func setWorkingDirectory(svc *service.Config, dir string) {
 	// WorkingDirectory is not supported on Windows.

--- a/cmd/cli/service.go
+++ b/cmd/cli/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/kardianos/service"
 
@@ -168,7 +169,11 @@ func doTasks(tasks []task) bool {
 				mainLog.Load().Error().Msgf("error running task %s: %v", task.Name, err)
 				return false
 			}
-			mainLog.Load().Debug().Msgf("error running task %s: %v", task.Name, err)
+			// if this is darwin stop command, dont print debug
+			// since launchctl complains on every start
+			if runtime.GOOS != "darwin" || task.Name != "Stop" {
+				mainLog.Load().Debug().Msgf("error running task %s: %v", task.Name, err)
+			}
 		}
 	}
 	return true

--- a/cmd/cli/service_others.go
+++ b/cmd/cli/service_others.go
@@ -18,3 +18,5 @@ func openLogFile(path string, flags int) (*os.File, error) {
 func hasLocalDnsServerRunning() bool { return false }
 
 func ConfigureWindowsServiceFailureActions(serviceName string) error { return nil }
+
+func isRunningOnDomainControllerWindows() (bool, int) { return false, 0 }

--- a/cmd/ctrld/main.go
+++ b/cmd/ctrld/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "github.com/Control-D-Inc/ctrld/cmd/cli"
+import (
+	"os"
+
+	"github.com/Control-D-Inc/ctrld/cmd/cli"
+)
 
 func main() {
 	cli.Main()
+	// make sure we exit with 0 if there are no errors
+	os.Exit(0)
 }

--- a/config.go
+++ b/config.go
@@ -529,7 +529,7 @@ func (uc *UpstreamConfig) newDOHTransport(addrs []string) *http.Transport {
 		for i := range addrs {
 			dialAddrs[i] = net.JoinHostPort(addrs[i], port)
 		}
-		conn, err := pd.DialContext(ctx, network, dialAddrs)
+		conn, err := pd.DialContext(ctx, network, dialAddrs, ProxyLogger.Load())
 		if err != nil {
 			return nil, err
 		}

--- a/docs/config.md
+++ b/docs/config.md
@@ -528,6 +528,15 @@ rules = [
 ]
 ```
 
+If there is no explicitly defined rules, LAN queries will be handled solely by the OS resolver.
+
+These following domains are considered LAN queries:
+
+- Queries does not have dot `.` in domain name, like `machine1`, `example`, ... (1)
+- Queries have domain ends with: `.domain`, `.lan`, `.local`.                   (2)
+- All `SRV` queries of LAN hostname (1) + (2).
+- `PTR` queries with private IPs.
+
 ---
 
 Note that the order of matching preference:

--- a/docs/config.md
+++ b/docs/config.md
@@ -166,7 +166,6 @@ before serving the query.
 
 ### max_concurrent_requests
 The number of concurrent requests that will be handled, must be a non-negative integer. 
-Tweaking this value depends on the capacity of your system.
 
 - Type: number
 - Required: no
@@ -253,9 +252,7 @@ Specifying the `ip` and `port` of the Prometheus metrics server. The Prometheus 
 - Default: ""
 
 ### dns_watchdog_enabled
-Checking DNS changes to network interfaces and reverting to ctrld's own settings.
-
-The DNS watchdog process only runs on Windows and MacOS, while in `--cd` mode. 
+Watches all physical interfaces for DNS changes and reverts them to ctrld's settings.The DNS watchdog process only runs on Windows and MacOS.
 
 - Type: boolean
 - Required: no
@@ -274,7 +271,7 @@ If the time duration is non-positive, default value will be used.
 - Default: 20s
 
 ### refetch_time
-Time in seconds between each iteration that reloads custom config if changed.
+Time in seconds between each iteration that reloads custom config from the API.
 
 The value must be a positive number, any invalid value will be ignored and default value will be used.
 - Type: number
@@ -282,7 +279,7 @@ The value must be a positive number, any invalid value will be ignored and defau
 - Default: 3600
 
 ### leak_on_upstream_failure
-Once ctrld is "offline", mean ctrld could not connect to any upstream, next queries will be leaked to OS resolver.
+If a remote upstream fails to resolve a query or is unreachable, `ctrld` will forward the queries to the default DNS resolver on the network. If failures persist, `ctrld` will remove itself from all networking interfaces until connectivity is restored. 
 
 - Type: boolean
 - Required: no

--- a/internal/clientinfo/client_info.go
+++ b/internal/clientinfo/client_info.go
@@ -207,11 +207,10 @@ func (t *Table) init() {
 		}
 		for platform, discover := range discovers {
 			if err := discover.refresh(); err != nil {
-				ctrld.ProxyLogger.Load().Error().Err(err).Msgf("could not init %s discover", platform)
-			} else {
-				t.hostnameResolvers = append(t.hostnameResolvers, discover)
-				t.refreshers = append(t.refreshers, discover)
+				ctrld.ProxyLogger.Load().Warn().Err(err).Msgf("failed to init %s discover", platform)
 			}
+			t.hostnameResolvers = append(t.hostnameResolvers, discover)
+			t.refreshers = append(t.refreshers, discover)
 		}
 	}
 	// Hosts file mapping.

--- a/internal/clientinfo/mdns.go
+++ b/internal/clientinfo/mdns.go
@@ -102,11 +102,14 @@ func (m *mdns) init(quitCh chan struct{}) error {
 			v4ConnList = append(v4ConnList, conn)
 			go m.readLoop(conn)
 		}
+		ctrld.ProxyLogger.Load().Debug().Msgf("checking for IPv6 availability in mdns init")
 		if ctrldnet.IPv6Available(context.Background()) {
 			if conn, err := net.ListenMulticastUDP("udp6", &iface, mdnsV6Addr); err == nil {
 				v6ConnList = append(v6ConnList, conn)
 				go m.readLoop(conn)
 			}
+		} else {
+			ctrld.ProxyLogger.Load().Debug().Msgf("IPv6 is not available in mdns init")
 		}
 	}
 

--- a/internal/clientinfo/mdns_services.go
+++ b/internal/clientinfo/mdns_services.go
@@ -67,4 +67,16 @@ var services = [...]string{
 
 	// Merlin
 	"_alexa._tcp",
+
+	// Newer Android TV devices
+	"_androidtvremote2._tcp.local.",
+
+	// https://esphome.io/
+	"_esphomelib._tcp.local.",
+
+	// https://www.home-assistant.io/
+	"_home-assistant._tcp.local.",
+
+	// https://kno.wled.ge/
+	"_wled._tcp.local.",
 }

--- a/internal/clientinfo/ubios.go
+++ b/internal/clientinfo/ubios.go
@@ -3,6 +3,7 @@ package clientinfo
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os/exec"
 	"strings"
@@ -44,9 +45,9 @@ func (u *ubiosDiscover) refreshDevices() error {
 	cmd := exec.Command("/usr/bin/mongo", "localhost:27117/ace", "--quiet", "--eval", `
 		DBQuery.shellBatchSize = 256;
 		db.user.find({name: {$exists: true, $ne: ""}}, {_id:0, mac:1, name:1});`)
-	b, err := cmd.Output()
+	b, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("out: %s, err: %w", string(b), err)
 	}
 	return u.storeDevices(bytes.NewReader(b))
 }

--- a/internal/controld/config.go
+++ b/internal/controld/config.go
@@ -32,6 +32,8 @@ const (
 	logURLCom          = apiURLCom + "/logs"
 	logURLDev          = apiURLDev + "/logs"
 	InvalidConfigCode  = 40402
+	defaultTimeout     = 20 * time.Second
+	sendLogTimeout     = 300 * time.Second
 )
 
 // ResolverConfig represents Control D resolver data.
@@ -135,7 +137,7 @@ func postUtilityAPI(version string, cdDev, lastUpdatedFailed bool, body io.Reade
 	req.Header.Add("Content-Type", "application/json")
 	transport := apiTransport(cdDev)
 	client := http.Client{
-		Timeout:   10 * time.Second,
+		Timeout:   defaultTimeout,
 		Transport: transport,
 	}
 	resp, err := client.Do(req)
@@ -176,7 +178,7 @@ func SendLogs(lr *LogsRequest, cdDev bool) error {
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	transport := apiTransport(cdDev)
 	client := http.Client{
-		Timeout:   300 * time.Second,
+		Timeout:   sendLogTimeout,
 		Transport: transport,
 	}
 	resp, err := client.Do(req)

--- a/internal/controld/config.go
+++ b/internal/controld/config.go
@@ -226,7 +226,7 @@ func apiTransport(cdDev bool) *http.Transport {
 			addrs[i] = net.JoinHostPort(ips[i], port)
 		}
 		d := &ctrldnet.ParallelDialer{}
-		return d.DialContext(ctx, network, addrs)
+		return d.DialContext(ctx, network, addrs, ctrld.ProxyLogger.Load())
 	}
 	if router.Name() == ddwrt.Name || runtime.GOOS == "android" {
 		transport.TLSClientConfig = &tls.Config{RootCAs: certs.CACertPool()}

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -3,6 +3,7 @@ package net
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"os/signal"
@@ -11,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/rs/zerolog"
 	"tailscale.com/logtail/backoff"
 )
 
@@ -26,7 +28,8 @@ var Dialer = &net.Dialer{
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 			d := ParallelDialer{}
 			d.Timeout = 10 * time.Second
-			return d.DialContext(ctx, "udp", []string{v4BootstrapDNS, v6BootstrapDNS})
+			l := zerolog.New(io.Discard)
+			return d.DialContext(ctx, "udp", []string{v4BootstrapDNS, v6BootstrapDNS}, &l)
 		},
 	},
 }
@@ -137,7 +140,7 @@ type ParallelDialer struct {
 	net.Dialer
 }
 
-func (d *ParallelDialer) DialContext(ctx context.Context, network string, addrs []string) (net.Conn, error) {
+func (d *ParallelDialer) DialContext(ctx context.Context, network string, addrs []string, logger *zerolog.Logger) (net.Conn, error) {
 	if len(addrs) == 0 {
 		return nil, errors.New("empty addresses")
 	}
@@ -157,11 +160,16 @@ func (d *ParallelDialer) DialContext(ctx context.Context, network string, addrs 
 	for _, addr := range addrs {
 		go func(addr string) {
 			defer wg.Done()
+			logger.Debug().Msgf("dialing to %s", addr)
 			conn, err := d.Dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				logger.Debug().Msgf("failed to dial %s: %v", addr, err)
+			}
 			select {
 			case ch <- &parallelDialerResult{conn: conn, err: err}:
 			case <-done:
 				if conn != nil {
+					logger.Debug().Msgf("connection closed: %s", conn.RemoteAddr())
 					conn.Close()
 				}
 			}
@@ -172,6 +180,7 @@ func (d *ParallelDialer) DialContext(ctx context.Context, network string, addrs 
 	for res := range ch {
 		if res.err == nil {
 			cancel()
+			logger.Debug().Msgf("connected to %s", res.conn.RemoteAddr())
 			return res.conn, res.err
 		}
 		errs = append(errs, res.err)

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -49,8 +49,12 @@ func init() {
 }
 
 func supportIPv6(ctx context.Context) bool {
-	_, err := probeStackDialer.DialContext(ctx, "tcp6", net.JoinHostPort(controldIPv6Test, "443"))
-	return err == nil
+	c, err := probeStackDialer.DialContext(ctx, "tcp6", v6BootstrapDNS)
+	if err != nil {
+		return false
+	}
+	c.Close()
+	return true
 }
 
 func supportListenIPv6Local() bool {

--- a/internal/router/openwrt/openwrt_test.go
+++ b/internal/router/openwrt/openwrt_test.go
@@ -1,0 +1,58 @@
+package openwrt
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Sample output from https://github.com/openwrt/openwrt/pull/16806#issuecomment-2448255734
+const ubusDnsmasqBefore2410 = `{
+	"dnsmasq": {
+		"instances": {
+			"guest_dns": {
+				"mount": {
+					"/tmp/dnsmasq.d": "0",
+					"/var/run/dnsmasq/": "1"
+				}
+			}
+		}
+	}
+}`
+
+const ubusDnsmasq2410 = `{
+	"dnsmasq": {
+		"instances": {
+			"guest_dns": {
+				"mount": {
+					"/tmp/dnsmasq.guest_dns.d": "0",
+					"/var/run/dnsmasq/": "1"
+				}
+			}
+		}
+	}
+}`
+
+func Test_dnsmasqConfPath(t *testing.T) {
+	var dnsmasq2410expected = filepath.Join("/tmp/dnsmasq.guest_dns.d", openwrtDNSMasqConfigName)
+	tests := []struct {
+		name     string
+		in       io.Reader
+		expected string
+	}{
+		{"empty", strings.NewReader(""), openwrtDnsmasqDefaultConfigPath},
+		{"invalid", strings.NewReader("}}"), openwrtDnsmasqDefaultConfigPath},
+		{"before 24.10", strings.NewReader(ubusDnsmasqBefore2410), openwrtDnsmasqDefaultConfigPath},
+		{"24.10", strings.NewReader(ubusDnsmasq2410), dnsmasq2410expected},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := dnsmasqConfPath(tc.in); got != tc.expected {
+				t.Errorf("dnsmasqConfPath() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -215,6 +215,20 @@ func LeaseFilesDir() string {
 	return ""
 }
 
+// ServiceDependencies returns list of dependencies that ctrld services needs on this router.
+// See https://pkg.go.dev/github.com/kardianos/service#Config for list format.
+func ServiceDependencies() []string {
+	if Name() == ubios.Name {
+		// On Ubios, ctrld needs to start after unifi-mongodb,
+		// so it can query custom client info mapping.
+		return []string{
+			"Wants=unifi-mongodb.service",
+			"After=unifi-mongodb.service",
+		}
+	}
+	return nil
+}
+
 func distroName() string {
 	switch {
 	case bytes.HasPrefix(unameO(), []byte("DD-WRT")):

--- a/internal/router/service_tomato.go
+++ b/internal/router/service_tomato.go
@@ -45,11 +45,15 @@ func (s *tomatoSvc) Platform() string {
 }
 
 func (s *tomatoSvc) configPath() string {
-	path, err := os.Executable()
-	if err != nil {
-		return ""
+	bin := s.Config.Executable
+	if bin == "" {
+		path, err := os.Executable()
+		if err != nil {
+			return ""
+		}
+		bin = path
 	}
-	return path + ".startup"
+	return bin + ".startup"
 }
 
 func (s *tomatoSvc) template() *template.Template {

--- a/internal/router/service_ubios.go
+++ b/internal/router/service_ubios.go
@@ -219,6 +219,8 @@ const ubiosBootSystemdService = `[Unit]
 Description=Run ctrld On Startup UDM
 Wants=network-online.target
 After=network-online.target
+Wants=unifi-mongodb
+After=unifi-mongodb
 StartLimitIntervalSec=500
 StartLimitBurst=5
 

--- a/log.go
+++ b/log.go
@@ -9,11 +9,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func init() {
-	l := zerolog.New(io.Discard)
-	ProxyLogger.Store(&l)
-}
-
 // ProxyLog emits the log record for proxy operations.
 // The caller should set it only once.
 // DEPRECATED: use ProxyLogger instead.

--- a/nameservers_darwin.go
+++ b/nameservers_darwin.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"os/exec"
 	"regexp"
@@ -243,4 +244,39 @@ func getAllDHCPNameservers() []string {
 	}
 
 	return allNameservers
+}
+
+func patchNetIfaceName(iface *net.Interface) (bool, error) {
+	b, err := exec.Command("networksetup", "-listnetworkserviceorder").Output()
+	if err != nil {
+		return false, err
+	}
+
+	patched := false
+	if name := networkServiceName(iface.Name, bytes.NewReader(b)); name != "" {
+		patched = true
+		iface.Name = name
+	}
+	return patched, nil
+}
+
+func networkServiceName(ifaceName string, r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	prevLine := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "*") {
+			// Network services is disabled.
+			continue
+		}
+		if !strings.Contains(line, "Device: "+ifaceName) {
+			prevLine = line
+			continue
+		}
+		parts := strings.SplitN(prevLine, " ", 2)
+		if len(parts) == 2 {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
 }

--- a/nameservers_windows.go
+++ b/nameservers_windows.go
@@ -17,7 +17,6 @@ import (
 	"github.com/microsoft/wmi/pkg/base/query"
 	"github.com/microsoft/wmi/pkg/constant"
 	"github.com/microsoft/wmi/pkg/hardware/network/netadapter"
-	"github.com/rs/zerolog"
 	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
 	"tailscale.com/net/netmon"
@@ -63,10 +62,7 @@ func dnsFromAdapter() []string {
 	var ns []string
 	var err error
 
-	logger := zerolog.New(io.Discard)
-	if ProxyLogger.Load() != nil {
-		logger = *ProxyLogger.Load()
-	}
+	logger := *ProxyLogger.Load()
 
 	for i := 0; i < maxDNSAdapterRetries; i++ {
 		if ctx.Err() != nil {
@@ -112,10 +108,8 @@ func dnsFromAdapter() []string {
 }
 
 func getDNSServers(ctx context.Context) ([]string, error) {
-	logger := zerolog.New(io.Discard)
-	if ProxyLogger.Load() != nil {
-		logger = *ProxyLogger.Load()
-	}
+	logger := *ProxyLogger.Load()
+
 	// Check context before making the call
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -343,10 +337,8 @@ func nameserversFromResolvconf() []string {
 // checkDomainJoined checks if the machine is joined to an Active Directory domain
 // Returns whether it's domain joined and the domain name if available
 func checkDomainJoined() bool {
-	logger := zerolog.New(io.Discard)
-	if ProxyLogger.Load() != nil {
-		logger = *ProxyLogger.Load()
-	}
+	logger := *ProxyLogger.Load()
+
 	var domain *uint16
 	var status uint32
 
@@ -423,10 +415,7 @@ func validInterfaces() map[string]struct{} {
 	defer log.SetOutput(os.Stderr)
 
 	//load the logger
-	logger := zerolog.New(io.Discard)
-	if ProxyLogger.Load() != nil {
-		logger = *ProxyLogger.Load()
-	}
+	logger := *ProxyLogger.Load()
 
 	whost := host.NewWmiLocalHost()
 	q := query.NewWmiQuery("MSFT_NetAdapter")

--- a/net.go
+++ b/net.go
@@ -18,6 +18,7 @@ const ipv6ProbingInterval = 10 * time.Second
 
 func hasIPv6() bool {
 	hasIPv6Once.Do(func() {
+		Log(context.Background(), ProxyLogger.Load().Debug(), "checking for IPv6 availability once")
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		val := ctrldnet.IPv6Available(ctx)
@@ -43,6 +44,7 @@ func probingIPv6(ctx context.Context, old bool) {
 				if ipv6Available.CompareAndSwap(old, cur) {
 					old = cur
 				}
+				Log(ctx, ProxyLogger.Load().Debug(), "IPv6 availability: %v", cur)
 			}()
 		}
 	}

--- a/resolver.go
+++ b/resolver.go
@@ -549,6 +549,11 @@ func lookupIP(domain string, timeout int, withBootstrapDNS bool) (ips []string) 
 //   - Gateway IP address (depends on OS).
 //   - Input servers.
 func NewBootstrapResolver(servers ...string) Resolver {
+	logger := zerolog.New(io.Discard)
+	if ProxyLogger.Load() != nil {
+		logger = *ProxyLogger.Load()
+	}
+	Log(context.Background(), logger.Debug(), "NewBootstrapResolver called with servers: %v", servers)
 	nss := defaultNameservers()
 	nss = append([]string{controldPublicDnsWithPort}, nss...)
 	for _, ns := range servers {
@@ -565,6 +570,13 @@ func NewBootstrapResolver(servers ...string) Resolver {
 //
 // This is useful for doing PTR lookup in LAN network.
 func NewPrivateResolver() Resolver {
+
+	logger := zerolog.New(io.Discard)
+	if ProxyLogger.Load() != nil {
+		logger = *ProxyLogger.Load()
+	}
+	Log(context.Background(), logger.Debug(), "NewPrivateResolver called")
+
 	nss := defaultNameservers()
 	resolveConfNss := nameserversFromResolvconf()
 	localRfc1918Addrs := Rfc1918Addresses()
@@ -609,6 +621,11 @@ func NewResolverWithNameserver(nameservers []string) Resolver {
 // newResolverWithNameserver returns an OS resolver from given nameservers list.
 // The caller must ensure each server in list is formed "ip:53".
 func newResolverWithNameserver(nameservers []string) *osResolver {
+	logger := zerolog.New(io.Discard)
+	if ProxyLogger.Load() != nil {
+		logger = *ProxyLogger.Load()
+	}
+	Log(context.Background(), logger.Debug(), "newResolverWithNameserver called with nameservers: %v", nameservers)
 	r := &osResolver{}
 	var publicNss []string
 	var lanNss []string

--- a/resolver.go
+++ b/resolver.go
@@ -289,8 +289,11 @@ func (o *osResolver) Resolve(ctx context.Context, msg *dns.Msg) (*dns.Msg, error
 			numServers--
 		}
 	}
-
-	Log(ctx, ProxyLogger.Load().Debug(), "os resolver query with nameservers: %v public: %v", nss, publicServers)
+	question := ""
+	if msg != nil && len(msg.Question) > 0 {
+		question = msg.Question[0].Name
+	}
+	Log(ctx, ProxyLogger.Load().Debug(), "os resolver query for %s with nameservers: %v public: %v", question, nss, publicServers)
 
 	// New check: If no resolvers are available, return an error.
 	if numServers == 0 {

--- a/staticdns.go
+++ b/staticdns.go
@@ -1,12 +1,8 @@
 package ctrld
 
 import (
-	"bufio"
-	"bytes"
-	"io"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -80,39 +76,4 @@ func SavedStaticNameservers(iface *net.Interface) ([]string, string) {
 		ns = append(ns, v)
 	}
 	return ns, file
-}
-
-func patchNetIfaceName(iface *net.Interface) (bool, error) {
-	b, err := exec.Command("networksetup", "-listnetworkserviceorder").Output()
-	if err != nil {
-		return false, err
-	}
-
-	patched := false
-	if name := networkServiceName(iface.Name, bytes.NewReader(b)); name != "" {
-		patched = true
-		iface.Name = name
-	}
-	return patched, nil
-}
-
-func networkServiceName(ifaceName string, r io.Reader) string {
-	scanner := bufio.NewScanner(r)
-	prevLine := ""
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, "*") {
-			// Network services is disabled.
-			continue
-		}
-		if !strings.Contains(line, "Device: "+ifaceName) {
-			prevLine = line
-			continue
-		}
-		parts := strings.SplitN(prevLine, " ", 2)
-		if len(parts) == 2 {
-			return strings.TrimSpace(parts[1])
-		}
-	}
-	return ""
 }

--- a/staticdns.go
+++ b/staticdns.go
@@ -1,0 +1,118 @@
+package ctrld
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var homedir string
+
+// absHomeDir returns the absolute path to given filename using home directory as root dir.
+func absHomeDir(filename string) string {
+	if homedir != "" {
+		return filepath.Join(homedir, filename)
+	}
+	dir, err := userHomeDir()
+	if err != nil {
+		return filename
+	}
+	return filepath.Join(dir, filename)
+}
+
+func dirWritable(dir string) (bool, error) {
+	f, err := os.CreateTemp(dir, "")
+	if err != nil {
+		return false, err
+	}
+	defer os.Remove(f.Name())
+	return true, f.Close()
+}
+
+func userHomeDir() (string, error) {
+	// viper will expand for us.
+	if runtime.GOOS == "windows" {
+		// If we're on windows, use the install path for this.
+		exePath, err := os.Executable()
+		if err != nil {
+			return "", err
+		}
+
+		return filepath.Dir(exePath), nil
+	}
+	dir := "/etc/controld"
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return os.UserHomeDir() // fallback to user home directory
+	}
+	if ok, _ := dirWritable(dir); !ok {
+		return os.UserHomeDir()
+	}
+	return dir, nil
+}
+
+// SavedStaticDnsSettingsFilePath returns the file path where the static DNS settings
+// for the provided interface are saved.
+func SavedStaticDnsSettingsFilePath(iface *net.Interface) string {
+	// The file is stored in the user home directory under a hidden file.
+	return absHomeDir(".dns_" + iface.Name)
+}
+
+// SavedStaticNameservers returns the stored static nameservers for the given interface.
+func SavedStaticNameservers(iface *net.Interface) ([]string, string) {
+	file := SavedStaticDnsSettingsFilePath(iface)
+	data, err := os.ReadFile(file)
+	if err != nil || len(data) == 0 {
+		return nil, file
+	}
+	saveValues := strings.Split(string(data), ",")
+	var ns []string
+	for _, v := range saveValues {
+		// Skip any IP that is loopback
+		if ip := net.ParseIP(v); ip != nil && ip.IsLoopback() {
+			continue
+		}
+		ns = append(ns, v)
+	}
+	return ns, file
+}
+
+func patchNetIfaceName(iface *net.Interface) (bool, error) {
+	b, err := exec.Command("networksetup", "-listnetworkserviceorder").Output()
+	if err != nil {
+		return false, err
+	}
+
+	patched := false
+	if name := networkServiceName(iface.Name, bytes.NewReader(b)); name != "" {
+		patched = true
+		iface.Name = name
+	}
+	return patched, nil
+}
+
+func networkServiceName(ifaceName string, r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	prevLine := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "*") {
+			// Network services is disabled.
+			continue
+		}
+		if !strings.Contains(line, "Device: "+ifaceName) {
+			prevLine = line
+			continue
+		}
+		parts := strings.SplitN(prevLine, " ", 2)
+		if len(parts) == 2 {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Minor Release

This contains new features, some performance improvements and bug fixes.

### Added
- This release adds support for OpenWrt 24.10 and newer versions, accommodating the updated dnsmasq configuration.

### Improved 
- The IPv6 checking mechanism has been redesigned to mitigate a potential Denial-of-Service (DoS) vulnerability affecting the Control D server.
- `ctrld` functionality is now extended to systems where a default route is not present, such as those employing VPNs or recent FreshTomato releases.
- Only SRV queries for LAN hostnames are resolved locally by the operating system.  Non-LAN queries are forwarded to a remote upstream server if no matching rules are defined.

### Fixed
- Fixed the problem where DNS configuration changes were not always being applied by systemd-resolved.
- Fixed the bug causing the `leak_on_upstream_failure=false` configuration to have no impact.
- Fixed the bug preventing ubios discovery from working after a system restart on UDM devices.
- Fixed the bug that caused runtime logs to be incorrectly formatted or missing.
- Fixed the bug where static DNS configuration on interfaces was ignored.
- Fixed a bug that prevented static DNS configurations from being restored after service stop/uninstall
- Fixed the bug causing HTTP transport failures after a network stack change.
- Fixed the bug that resulted in the OS resolver not using public DNS servers for LAN queries.
- Fixed the problem where Windows DNS forwarders were not always set correctly after system reboot.
- Fixed an issue where invalid remote custom configurations were not properly validated.