### PR TITLE
Add OPNsense new dnsmasq lease file

### DIFF
--- a/internal/clientinfo/dhcp_lease_files.go
+++ b/internal/clientinfo/dhcp_lease_files.go
@@ -16,4 +16,5 @@ var clientInfoFiles = map[string]ctrld.LeaseFileFormat{
 	"/var/dhcpd/var/db/dhcpd.leases":           ctrld.IscDhcpd, // Pfsense
 	"/home/pi/.router/run/dhcp/dnsmasq.leases": ctrld.Dnsmasq,  // Firewalla
 	"/var/lib/kea/dhcp4.leases":                ctrld.KeaDHCP4, // Pfsense
+	"/var/db/dnsmasq.leases":                   ctrld.Dnsmasq,  // OPNsense
 }


### PR DESCRIPTION
Since OPNsense 25.1.7 the old ISP DHCP has been deprecated. Dnsmasq is the preferred method (or kea if you have a large operation). Add lease files for the dnsmasq config location.