### PR TITLE
feat: enable client info for custom DoH/DoH3 upstreams

### DIFF
--- a/config.go
+++ b/config.go
@@ -385,7 +385,7 @@ func (uc *UpstreamConfig) VerifyDomain() string {
 }
 
 // UpstreamSendClientInfo reports whether the upstream is
-// configured to send client info to Control D DNS server.
+// configured to send client info to the DNS server.
 //
 // Client info includes:
 //   - MAC

--- a/doh.go
+++ b/doh.go
@@ -159,6 +159,9 @@ func addHeader(ctx context.Context, req *http.Request, uc *UpstreamConfig) {
 				dohHeader = newControlDHeaders(ci)
 			case uc.isNextDNS():
 				dohHeader = newNextDNSHeaders(ci)
+		        default:
+			     // For custom upstreams with send_client_info enabled, use ControlD-style headers	
+			     dohHeader = newControlDHeaders(ci)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
This PR enables sending client information (hostname, IP address, MAC address) to custom DoH/DoH3 upstream servers when `send_client_info = true` is configured. Currently, this feature only works for ControlD and NextDNS upstreams.

## Changes
- Modified `addHeader()` function in `doh.go` to add a `default` case that sends ControlD-style headers for custom upstreams when `send_client_info = true`
- Updated comment in `config.go` to reflect that client info can be sent to any DNS server, not just ControlD

## Behavior
When `send_client_info = true` is set for a custom upstream server:
- The same headers used for ControlD upstreams are sent: `x-cd-host`, `x-cd-ip`, `x-cd-mac`, etc.
- This allows custom DNS servers to receive client identification information
- The feature only works for `doh` and `doh3` upstream types (as documented)

## Use Case
This enables users to configure custom DNS servers that can identify and log client information, similar to how ControlD and NextDNS servers receive this information.

## Testing
- [X] Tested with a custom DoH upstream server
- [X] Verified headers are sent correctly when `send_client_info = true`
- [X] Verified no headers are sent when `send_client_info = false` (default)
- [X] Verified existing ControlD and NextDNS functionality still works

Fixes #280 

I *think* this is the first PR I've ever submitted, so if I'm doing something wrong, please tell me...