### PR TITLE
proxy: add random upstream selection strategy

### DIFF
--- a/cmd/cli/dns_proxy.go
+++ b/cmd/cli/dns_proxy.go
@@ -76,12 +76,13 @@ type proxyResponse struct {
 
 // upstreamForResult represents the result of processing rules for a request.
 type upstreamForResult struct {
-	upstreams      []string
-	matchedPolicy  string
-	matchedNetwork string
-	matchedRule    string
-	matched        bool
-	srcAddr        string
+	upstreams        []string
+	upstreamStrategy string
+	matchedPolicy    string
+	matchedNetwork   string
+	matchedRule      string
+	matched          bool
+	srcAddr          string
 }
 
 func (p *prog) serveDNS(listenerNum string) error {
@@ -257,6 +258,7 @@ func (p *prog) serveDNS(listenerNum string) error {
 // is disregarded in favor of the domain level rule.
 func (p *prog) upstreamFor(ctx context.Context, defaultUpstreamNum string, lc *ctrld.ListenerConfig, addr net.Addr, srcMac, domain string) (res *upstreamForResult) {
 	upstreams := []string{upstreamPrefix + defaultUpstreamNum}
+	upstreamStrategy := ctrld.UpstreamStrategySequential
 	matchedPolicy := "no policy"
 	matchedNetwork := "no network"
 	matchedRule := "no rule"
@@ -265,6 +267,7 @@ func (p *prog) upstreamFor(ctx context.Context, defaultUpstreamNum string, lc *c
 
 	defer func() {
 		res.upstreams = upstreams
+		res.upstreamStrategy = upstreamStrategy
 		res.matched = matched
 		res.matchedPolicy = matchedPolicy
 		res.matchedNetwork = matchedNetwork
@@ -274,6 +277,7 @@ func (p *prog) upstreamFor(ctx context.Context, defaultUpstreamNum string, lc *c
 	if lc.Policy == nil {
 		return
 	}
+	upstreamStrategy = lc.Policy.UpstreamStrategyOrDefault()
 
 	do := func(policyUpstreams []string) {
 		upstreams = append([]string(nil), policyUpstreams...)
@@ -486,6 +490,9 @@ func (p *prog) proxy(ctx context.Context, req *proxyRequest) *proxyResponse {
 		}
 	}
 
+	if !isLanOrPtrQuery {
+		upstreams, upstreamConfigs = orderUpstreams(req.ufr.upstreamStrategy, upstreams, upstreamConfigs)
+	}
 	// Inverse query should not be cached: https://www.rfc-editor.org/rfc/rfc1035#section-7.4
 	if p.cache != nil && req.msg.Question[0].Qtype != dns.TypePTR {
 		for _, upstream := range upstreams {

--- a/cmd/cli/dns_proxy_test.go
+++ b/cmd/cli/dns_proxy_test.go
@@ -134,12 +134,35 @@ func Test_prog_upstreamFor(t *testing.T) {
 				})
 				assert.Equal(t, tc.matched, ufr.matched)
 				assert.Equal(t, tc.upstreams, ufr.upstreams)
+				assert.Equal(t, ctrld.UpstreamStrategySequential, ufr.upstreamStrategy)
 				if tc.testLogMsg != "" {
 					assert.Contains(t, logOutput.String(), tc.testLogMsg)
 				}
 			}
 		})
 	}
+}
+
+func Test_prog_upstreamForPolicyUpstreamStrategy(t *testing.T) {
+	cfg := testhelper.SampleConfig(t)
+	cfg.Listener["0"].Policy.UpstreamStrategy = ctrld.UpstreamStrategyRandom
+	p := &prog{cfg: cfg}
+	for _, nc := range p.cfg.Network {
+		for _, cidr := range nc.Cidrs {
+			_, ipNet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			nc.IPNets = append(nc.IPNets, ipNet)
+		}
+	}
+	addr, err := net.ResolveUDPAddr("udp", "192.168.0.1:0")
+	require.NoError(t, err)
+
+	ufr := p.upstreamFor(context.Background(), "0", p.cfg.Listener["0"], addr, "", "abc.xyz")
+
+	assert.Equal(t, ctrld.UpstreamStrategyRandom, ufr.upstreamStrategy)
+	assert.Equal(t, []string{"upstream.1", "upstream.0"}, ufr.upstreams)
 }
 
 func TestCache(t *testing.T) {

--- a/cmd/cli/upstream_strategy.go
+++ b/cmd/cli/upstream_strategy.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"math/rand"
+
+	"github.com/Control-D-Inc/ctrld"
+)
+
+func orderUpstreams(strategy string, upstreams []string, upstreamConfigs []*ctrld.UpstreamConfig) ([]string, []*ctrld.UpstreamConfig) {
+	return orderUpstreamsWithShuffle(strategy, upstreams, upstreamConfigs, rand.Shuffle)
+}
+
+func orderUpstreamsWithShuffle(
+	strategy string,
+	upstreams []string,
+	upstreamConfigs []*ctrld.UpstreamConfig,
+	shuffle func(n int, swap func(i, j int)),
+) ([]string, []*ctrld.UpstreamConfig) {
+	orderedUpstreams := append([]string(nil), upstreams...)
+	orderedUpstreamConfigs := append([]*ctrld.UpstreamConfig(nil), upstreamConfigs...)
+	if strategy != ctrld.UpstreamStrategyRandom || len(orderedUpstreams) <= 1 || len(orderedUpstreams) != len(orderedUpstreamConfigs) {
+		return orderedUpstreams, orderedUpstreamConfigs
+	}
+	shuffle(len(orderedUpstreams), func(i, j int) {
+		orderedUpstreams[i], orderedUpstreams[j] = orderedUpstreams[j], orderedUpstreams[i]
+		orderedUpstreamConfigs[i], orderedUpstreamConfigs[j] = orderedUpstreamConfigs[j], orderedUpstreamConfigs[i]
+	})
+	return orderedUpstreams, orderedUpstreamConfigs
+}

--- a/cmd/cli/upstream_strategy_test.go
+++ b/cmd/cli/upstream_strategy_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Control-D-Inc/ctrld"
+)
+
+func Test_orderUpstreamsSequentialPreservesOrderAndPairing(t *testing.T) {
+	upstreams := []string{"upstream.0", "upstream.1", "upstream.2"}
+	upstreamConfigs := []*ctrld.UpstreamConfig{
+		{Name: "zero"},
+		{Name: "one"},
+		{Name: "two"},
+	}
+
+	gotUpstreams, gotUpstreamConfigs := orderUpstreams(ctrld.UpstreamStrategySequential, upstreams, upstreamConfigs)
+
+	assert.Equal(t, upstreams, gotUpstreams)
+	assert.Equal(t, []string{"zero", "one", "two"}, upstreamConfigNames(gotUpstreamConfigs))
+
+	gotUpstreams[0] = "changed"
+	gotUpstreamConfigs[0] = &ctrld.UpstreamConfig{Name: "changed"}
+	assert.Equal(t, []string{"upstream.0", "upstream.1", "upstream.2"}, upstreams)
+	assert.Equal(t, []string{"zero", "one", "two"}, upstreamConfigNames(upstreamConfigs))
+}
+
+func Test_orderUpstreamsRandomUsesShuffleAndPreservesPairing(t *testing.T) {
+	upstreams := []string{"upstream.0", "upstream.1", "upstream.2"}
+	upstreamConfigs := []*ctrld.UpstreamConfig{
+		{Name: "zero"},
+		{Name: "one"},
+		{Name: "two"},
+	}
+
+	gotUpstreams, gotUpstreamConfigs := orderUpstreamsWithShuffle(
+		ctrld.UpstreamStrategyRandom,
+		upstreams,
+		upstreamConfigs,
+		func(n int, swap func(i, j int)) {
+			require.Equal(t, 3, n)
+			swap(0, 2)
+			swap(1, 2)
+		},
+	)
+
+	assert.Equal(t, []string{"upstream.2", "upstream.0", "upstream.1"}, gotUpstreams)
+	assert.Equal(t, []string{"two", "zero", "one"}, upstreamConfigNames(gotUpstreamConfigs))
+	assert.Equal(t, []string{"upstream.0", "upstream.1", "upstream.2"}, upstreams)
+	assert.Equal(t, []string{"zero", "one", "two"}, upstreamConfigNames(upstreamConfigs))
+}
+
+func Test_orderUpstreamsUnknownStrategyBehavesAsSequential(t *testing.T) {
+	upstreams := []string{"upstream.0", "upstream.1"}
+	upstreamConfigs := []*ctrld.UpstreamConfig{
+		{Name: "zero"},
+		{Name: "one"},
+	}
+	called := false
+
+	gotUpstreams, gotUpstreamConfigs := orderUpstreamsWithShuffle(
+		"unknown",
+		upstreams,
+		upstreamConfigs,
+		func(n int, swap func(i, j int)) {
+			called = true
+		},
+	)
+
+	assert.False(t, called)
+	assert.Equal(t, upstreams, gotUpstreams)
+	assert.Equal(t, []string{"zero", "one"}, upstreamConfigNames(gotUpstreamConfigs))
+}
+
+func Test_orderUpstreamsRandomLengthMismatchBehavesAsSequential(t *testing.T) {
+	upstreams := []string{"upstream.0", "upstream.1"}
+	upstreamConfigs := []*ctrld.UpstreamConfig{
+		{Name: "zero"},
+	}
+	called := false
+
+	gotUpstreams, gotUpstreamConfigs := orderUpstreamsWithShuffle(
+		ctrld.UpstreamStrategyRandom,
+		upstreams,
+		upstreamConfigs,
+		func(n int, swap func(i, j int)) {
+			called = true
+		},
+	)
+
+	assert.False(t, called)
+	assert.Equal(t, upstreams, gotUpstreams)
+	assert.Equal(t, []string{"zero"}, upstreamConfigNames(gotUpstreamConfigs))
+}
+
+func upstreamConfigNames(upstreamConfigs []*ctrld.UpstreamConfig) []string {
+	names := make([]string, 0, len(upstreamConfigs))
+	for _, upstreamConfig := range upstreamConfigs {
+		if upstreamConfig == nil {
+			names = append(names, "")
+			continue
+		}
+		names = append(names, upstreamConfig.Name)
+	}
+	return names
+}

--- a/config.go
+++ b/config.go
@@ -49,6 +49,11 @@ const (
 	// depending on the record type of the DNS query.
 	IpStackSplit = "split"
 
+	// UpstreamStrategySequential tries matched upstreams in configured order.
+	UpstreamStrategySequential = "sequential"
+	// UpstreamStrategyRandom randomly reorders matched upstreams before trying them.
+	UpstreamStrategyRandom = "random"
+
 	// FreeDnsDomain is the domain name of free ControlD service.
 	FreeDnsDomain = "freedns.controld.com"
 	// FreeDNSBoostrapIP is the IP address of freedns.controld.com.
@@ -315,8 +320,18 @@ type ListenerPolicyConfig struct {
 	Networks             []Rule   `mapstructure:"networks" toml:"networks,omitempty,inline,multiline" validate:"dive,len=1"`
 	Rules                []Rule   `mapstructure:"rules" toml:"rules,omitempty,inline,multiline" validate:"dive,len=1"`
 	Macs                 []Rule   `mapstructure:"macs" toml:"macs,omitempty,inline,multiline" validate:"dive,len=1"`
+	UpstreamStrategy     string   `mapstructure:"upstream_strategy" toml:"upstream_strategy,omitempty" validate:"omitempty,oneof=sequential random"`
 	FailoverRcodes       []string `mapstructure:"failover_rcodes" toml:"failover_rcodes,omitempty" validate:"dive,dnsrcode"`
 	FailoverRcodeNumbers []int    `mapstructure:"-" toml:"-"`
+}
+
+// UpstreamStrategyOrDefault returns the configured upstream strategy, or the
+// sequential strategy if no policy or strategy is configured.
+func (pc *ListenerPolicyConfig) UpstreamStrategyOrDefault() string {
+	if pc == nil || pc.UpstreamStrategy == "" {
+		return UpstreamStrategySequential
+	}
+	return pc.UpstreamStrategy
 }
 
 // Rule is a map from source to list of upstreams.

--- a/config_test.go
+++ b/config_test.go
@@ -131,6 +131,40 @@ func TestConfigValidation(t *testing.T) {
 	}
 }
 
+func TestConfigValidationUpstreamStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy string
+		wantErr  bool
+	}{
+		{"omitted", "", false},
+		{"sequential", ctrld.UpstreamStrategySequential, false},
+		{"random", ctrld.UpstreamStrategyRandom, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := defaultConfig(t)
+			cfg.Listener["0"].Policy.UpstreamStrategy = tc.strategy
+			validate := validator.New()
+
+			err := ctrld.ValidateConfig(validate, cfg)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestListenerPolicyConfigUpstreamStrategyOrDefault(t *testing.T) {
+	assert.Equal(t, ctrld.UpstreamStrategySequential, (*ctrld.ListenerPolicyConfig)(nil).UpstreamStrategyOrDefault())
+	assert.Equal(t, ctrld.UpstreamStrategySequential, (&ctrld.ListenerPolicyConfig{}).UpstreamStrategyOrDefault())
+	assert.Equal(t, ctrld.UpstreamStrategyRandom, (&ctrld.ListenerPolicyConfig{UpstreamStrategy: ctrld.UpstreamStrategyRandom}).UpstreamStrategyOrDefault())
+}
+
 func TestConfigValidationDoNotChangeEndpoint(t *testing.T) {
 	cfg := configWithInvalidDoHEndpoint(t)
 	endpointMap := map[string]struct{}{}

--- a/docs/config.md
+++ b/docs/config.md
@@ -593,6 +593,22 @@ Note that the domain comparisons are done in case in-sensitive manner following 
 - Required: no
 - Default: []
 
+### upstream_strategy
+`upstream_strategy` controls the order in which matched upstreams are tried for each query.
+
+Valid values:
+
+- `sequential`: try upstreams in the configured order.
+- `random`: randomly reorder the matched upstreams for each query, then try them in that order.
+
+Both strategies use the same sequential failover behavior. Timeouts, `failover_rcodes`, cache behavior, stale cache behavior, recovery, and `leak_on_upstream_failure` are unchanged.
+
+Use `random` only with equivalent upstreams, since any matched upstream may be tried first.
+
+- Type: string
+- Required: no
+- Default: `sequential`
+
 ### failover_rcodes
 For non success response, `failover_rcodes` allows the request to be forwarded to next upstream, if the response `RCODE` matches any value defined in `failover_rcodes`.
 


### PR DESCRIPTION
## Summary

This PR adds an optional `upstream_strategy` field to listener policies. ctrld currently tries matched upstreams in strict configured order, so `upstream.0` takes all initial load and the rest act as failover only. This adds:

- `sequential` (default): current behavior, configured order.
- `random`: matched upstreams are shuffled per query to spread load across equivalent upstreams.

After ordering, the same sequential failover runs, so timeouts, `failover_rcodes`, caching, recovery, and `leak_on_upstream_failure` are unchanged. The default is unchanged, and LAN/PTR queries are never reordered.

## Config

```toml
[listener.0.policy]
  name = "h3-only"
  upstream_strategy = "random"
  networks = [
    { "network.0" = ["upstream.0", "upstream.1", "upstream.2", "upstream.3"] },
  ]
```

## Testing

Unit tests cover ordering (sequential preserves order and pairing, random uses the shuffle, unknown/mismatch fall back to sequential), policy validation, and strategy propagation through `upstreamFor`. `go test ./...`, `go vet`, `gofmt -l`, and `go test -race ./cmd/cli/` are clean; `go mod tidy` produces no diff. No new dependencies.

Verified on a Pi 5, 200 queries with unique labels, counting the first upstream tried per query:

- absent / `sequential`: all on `upstream.0`
- `random`: roughly even spread across all four

I'll be happy to rebase onto `release-branch-v2.0.0` if that is the preferred base.