### PR TITLE
go.mod: bump insomniacslk/dhcp past the nclient4 ReadFrom panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/illarion/gonotify/v2 v2.0.3
-	github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2
+	github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82
 	github.com/jaytaylor/go-hostsfile v0.0.0-20220426042432-61485ac1fa6c
 	github.com/josharian/native v1.1.1-0.20230202152459-5c7d0dd6ab86
 	github.com/kardianos/service v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/illarion/gonotify/v2 v2.0.3 h1:B6+SKPo/0Sw8cRJh1aLzNEeNVFfzE3c6N+o+vy
 github.com/illarion/gonotify/v2 v2.0.3/go.mod h1:38oIJTgFqupkEydkkClkbL6i5lXV/bxdH9do5TALPEE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2 h1:9K06NfxkBh25x56yVhWWlKFE8YpicaSfHwoV8SFbueA=
-github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2/go.mod h1:3A9PQ1cunSDF/1rbTq99Ts4pVnycWg+vlPkfeD2NLFI=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82 h1:y5aU8Uvl7eyM5WNgdQvRxbMJb+zo7pD+S72/Yo4pvnQ=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
 github.com/jaytaylor/go-hostsfile v0.0.0-20220426042432-61485ac1fa6c h1:kbTQ8oGf+BVFvt/fM+ECI+NbZDCqoi0vtZTfB2p2hrI=
 github.com/jaytaylor/go-hostsfile v0.0.0-20220426042432-61485ac1fa6c/go.mod h1:k6+89xKz7BSMJ+DzIerBdtpEUeTlBMugO/hcVSzahog=
 github.com/josharian/native v1.0.1-0.20221213033349-c1e37c09b531/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=


### PR DESCRIPTION
ctrld's Linux DNS restore path re-reads the DHCP nameservers with a default nclient4 client. `resetDNS` in `cmd/cli/os_linux.go` calls `nclient4.New(iface.Name)` then `c.Request(ctx)`, with no `WithUnicast`, so replies come back through `BroadcastRawUDPConn.ReadFrom`.

Before insomniacslk/dhcp#583, `ReadFrom` subtracted the 8-byte UDP header from the IPv4 payload length without checking the payload was that long, so a reply declaring fewer than 8 bytes gave a negative slice bound and panicked, which could crash the restore path. I wrote the fix; it drops frames whose IPv4 payload is shorter than the UDP header instead of computing a negative length.

This bumps the pin from `v0.0.0-20231206064809-8c70d406f6d2` (2023-12) to the #583 merge commit. Only go.mod and go.sum change; `go build ./...` passes and `go vet ./cmd/cli/` is clean. No CVE, and I haven't tried to reproduce a crash inside ctrld.
